### PR TITLE
 Extended tests and fixed calculateLateralDimensions()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Latest changes
 * Extended documentation
-* Increase testcoverag
+* Increase test coverage
 * Fixed calculateLateralDimensions()
 * Extended extractSituation() by timeIndex parameter
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Latest changes
 * Extended documentation
+* Increase testcoverag
+* Fixed calculateLateralDimensions()
+* Extended extractSituation() by timeIndex parameter
 
 ## Release 1.0.0
 * Initial release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ set(BUILD_COVERAGE "OFF" CACHE BOOL "Enable test coverage")
 
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
-project(ad_rss_lib VERSION 1.0)
+project(ad_rss_lib VERSION 1.0.1)
 
 set(CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_STANDARD 11)

--- a/include/ad_rss/core/RssResponseResolving.hpp
+++ b/include/ad_rss/core/RssResponseResolving.hpp
@@ -67,7 +67,7 @@ public:
   /**
    * @brief Calculate the proper response out of the current responses
    *
-   * @param[in]  currentResponseState all the response states gathered for the current situations
+   * @param[in]  currentResponseStates all the response states gathered for the current situations
    * @param[out] responseState the proper overall response state
    *
    * @return true if response could be calculated, false otherwise

--- a/include/ad_rss/core/RssSituationChecking.hpp
+++ b/include/ad_rss/core/RssSituationChecking.hpp
@@ -87,7 +87,7 @@ public:
    * @brief Checks if the current situations are safe.
    *
    * @param [in] situationVector the vector of situations that should be analyzed
-   * @param[out] responseVector the vector of response states for the current situations
+   * @param[out] responseStateVector the vector of response states for the current situations
    *
    * @return true if the situations could be analyzed, false if an error occurred during evaluation.
    */

--- a/include/ad_rss/physics/Operations.hpp
+++ b/include/ad_rss/physics/Operations.hpp
@@ -157,7 +157,7 @@ inline ad_rss::physics::Distance operator*(ad_rss::physics::ParametricValue cons
 /*!
  * \brief Arithmetic physics operation t = s / v
  *
- * \param[in] d distance value
+ * \param[in] s distance value
  * \param[in] v speed value
  *
  * \returns t = s / v as duration value

--- a/src/core/RssSituationExtraction.cpp
+++ b/src/core/RssSituationExtraction.cpp
@@ -270,7 +270,8 @@ bool convertObjectsIntersection(world::Object const &egoVehicle,
   return result;
 }
 
-bool extractSituationInputRangeChecked(world::Object const &egoVehicle,
+bool extractSituationInputRangeChecked(physics::TimeIndex const &timeIndex,
+                                       world::Object const &egoVehicle,
                                        world::Scene const &currentScene,
                                        situation::Situation &situation)
 {
@@ -288,6 +289,7 @@ bool extractSituationInputRangeChecked(world::Object const &egoVehicle,
 
   try
   {
+    situation.timeIndex = timeIndex;
     situation.situationId = situation::SituationId(currentScene.object.objectId);
     situation.situationType = currentScene.situationType;
 
@@ -342,7 +344,8 @@ bool extractSituationInputRangeChecked(world::Object const &egoVehicle,
   return result;
 }
 
-bool extractSituation(world::Object const &egoVehicle,
+bool extractSituation(physics::TimeIndex const &timeIndex,
+                      world::Object const &egoVehicle,
                       world::Scene const &currentScene,
                       situation::Situation &situation)
 {
@@ -351,7 +354,7 @@ bool extractSituation(world::Object const &egoVehicle,
     return false;
   }
 
-  return extractSituationInputRangeChecked(egoVehicle, currentScene, situation);
+  return extractSituationInputRangeChecked(timeIndex, egoVehicle, currentScene, situation);
 }
 
 bool extractSituations(world::WorldModel const &worldModel, situation::SituationVector &situationVector)
@@ -367,8 +370,8 @@ bool extractSituations(world::WorldModel const &worldModel, situation::Situation
     for (auto const &scene : worldModel.scenes)
     {
       situation::Situation situation;
-      situation.timeIndex = worldModel.timeIndex;
-      bool const extractResult = extractSituationInputRangeChecked(worldModel.egoVehicle, scene, situation);
+      bool const extractResult
+        = extractSituationInputRangeChecked(worldModel.timeIndex, worldModel.egoVehicle, scene, situation);
 
       // if the situation is relevant, add it to situationVector
       if (scene.situationType != ad_rss::situation::SituationType::NotRelevant)

--- a/tests/core/RssSituationExtractionIntersectionTests.cpp
+++ b/tests/core/RssSituationExtractionIntersectionTests.cpp
@@ -149,6 +149,10 @@ TEST_F(RssSituationExtractionIntersectionTests, noLongitudinalDifference)
 
   ASSERT_EQ(situationVector[0].relativePosition.lateralPosition, ::ad_rss::situation::LateralRelativePosition::Overlap);
   ASSERT_EQ(situationVector[0].relativePosition.lateralDistance, Distance(0));
+
+  situation::Situation situation;
+  ASSERT_TRUE(extractSituation(worldModel.timeIndex, worldModel.egoVehicle, worldModel.scenes[0], situation));
+  ASSERT_EQ(situation, situationVector[0]);
 }
 
 TEST_F(RssSituationExtractionIntersectionTests, longitudinalDifference)
@@ -217,6 +221,10 @@ TEST_F(RssSituationExtractionIntersectionTests, longitudinalDifference)
 
   ASSERT_EQ(situationVector[0].relativePosition.lateralPosition, ::ad_rss::situation::LateralRelativePosition::Overlap);
   ASSERT_EQ(situationVector[0].relativePosition.lateralDistance, Distance(0));
+
+  situation::Situation situation;
+  ASSERT_TRUE(extractSituation(worldModel.timeIndex, worldModel.egoVehicle, worldModel.scenes[0], situation));
+  ASSERT_EQ(situation, situationVector[0]);
 }
 
 } // namespace RssSituationExtraction

--- a/tests/core/RssSituationExtractionOppositeDirectionTests.cpp
+++ b/tests/core/RssSituationExtractionOppositeDirectionTests.cpp
@@ -117,6 +117,10 @@ TEST_F(RssSituationExtractionOppositeDirectionTests, noLongitudinalDifference)
 
   ASSERT_EQ(situationVector[0].relativePosition.lateralPosition, ::ad_rss::situation::LateralRelativePosition::AtLeft);
   ASSERT_EQ(situationVector[0].relativePosition.lateralDistance, Distance(1));
+
+  situation::Situation situation;
+  ASSERT_TRUE(extractSituation(worldModel.timeIndex, worldModel.egoVehicle, worldModel.scenes[0], situation));
+  ASSERT_EQ(situation, situationVector[0]);
 }
 
 TEST_F(RssSituationExtractionOppositeDirectionTests, longitudinalDifference)
@@ -156,6 +160,10 @@ TEST_F(RssSituationExtractionOppositeDirectionTests, longitudinalDifference)
 
   ASSERT_EQ(situationVector[0].relativePosition.lateralPosition, ::ad_rss::situation::LateralRelativePosition::AtRight);
   ASSERT_EQ(situationVector[0].relativePosition.lateralDistance, Distance(1));
+
+  situation::Situation situation;
+  ASSERT_TRUE(extractSituation(worldModel.timeIndex, worldModel.egoVehicle, worldModel.scenes[0], situation));
+  ASSERT_EQ(situation, situationVector[0]);
 }
 
 } // namespace RssSituationExtraction

--- a/tests/core/RssSituationExtractionSameDirectionTests.cpp
+++ b/tests/core/RssSituationExtractionSameDirectionTests.cpp
@@ -116,6 +116,10 @@ TEST_F(RssSituationExtractionSameDirectionTests, noLongitudinalDifference)
 
   ASSERT_EQ(situationVector[0].relativePosition.lateralPosition, ::ad_rss::situation::LateralRelativePosition::AtLeft);
   ASSERT_EQ(situationVector[0].relativePosition.lateralDistance, Distance(1));
+
+  situation::Situation situation;
+  ASSERT_TRUE(extractSituation(worldModel.timeIndex, worldModel.egoVehicle, worldModel.scenes[0], situation));
+  ASSERT_EQ(situation, situationVector[0]);
 }
 
 TEST_F(RssSituationExtractionSameDirectionTests, longitudinalDifferenceEgoLeading)
@@ -152,6 +156,10 @@ TEST_F(RssSituationExtractionSameDirectionTests, longitudinalDifferenceEgoLeadin
 
   ASSERT_EQ(situationVector[0].relativePosition.lateralPosition, ::ad_rss::situation::LateralRelativePosition::AtLeft);
   ASSERT_EQ(situationVector[0].relativePosition.lateralDistance, Distance(1));
+
+  situation::Situation situation;
+  ASSERT_TRUE(extractSituation(worldModel.timeIndex, worldModel.egoVehicle, worldModel.scenes[0], situation));
+  ASSERT_EQ(situation, situationVector[0]);
 }
 
 TEST_F(RssSituationExtractionSameDirectionTests, longitudinalDifferenceEgoFollowing)
@@ -188,6 +196,10 @@ TEST_F(RssSituationExtractionSameDirectionTests, longitudinalDifferenceEgoFollow
 
   ASSERT_EQ(situationVector[0].relativePosition.lateralPosition, ::ad_rss::situation::LateralRelativePosition::AtRight);
   ASSERT_EQ(situationVector[0].relativePosition.lateralDistance, Distance(1));
+
+  situation::Situation situation;
+  ASSERT_TRUE(extractSituation(worldModel.timeIndex, worldModel.egoVehicle, worldModel.scenes[0], situation));
+  ASSERT_EQ(situation, situationVector[0]);
 }
 
 } // namespace RssSituationExtraction

--- a/tests/test_support/TestSupport.hpp
+++ b/tests/test_support/TestSupport.hpp
@@ -38,6 +38,7 @@
 #include "RSSParameters.hpp"
 #include "ad_rss/physics/Operations.hpp"
 #include "ad_rss/situation/RelativePosition.hpp"
+#include "ad_rss/situation/Situation.hpp"
 #include "ad_rss/situation/VehicleState.hpp"
 #include "ad_rss/state/ResponseState.hpp"
 #include "ad_rss/world/Object.hpp"
@@ -257,6 +258,53 @@ inline bool operator==(::ad_rss::state::LongitudinalRssState const &left,
 inline bool operator==(::ad_rss::state::LateralRssState const &left, ::ad_rss::state::LateralRssState const &right)
 {
   return (left.isSafe == right.isSafe) && (left.response == right.response);
+}
+
+inline bool operator==(::ad_rss::situation::RelativePosition const &left,
+                       ::ad_rss::situation::RelativePosition const &right)
+{
+  return (left.lateralDistance == right.lateralDistance) && (left.longitudinalDistance == right.longitudinalDistance)
+    && (left.lateralPosition == right.lateralPosition) && (left.lateralDistance == right.lateralDistance);
+}
+
+inline bool operator==(::ad_rss::world::Velocity const &left, ::ad_rss::world::Velocity const &right)
+{
+  return (left.speedLat == right.speedLat) && (left.speedLon == right.speedLon);
+}
+
+inline bool operator==(::ad_rss::world::LateralRssAccelerationValues const &left,
+                       ::ad_rss::world::LateralRssAccelerationValues const &right)
+{
+  return (left.accelMax == right.accelMax) && (left.brakeMin == right.brakeMin);
+}
+
+inline bool operator==(::ad_rss::world::LongitudinalRssAccelerationValues const &left,
+                       ::ad_rss::world::LongitudinalRssAccelerationValues const &right)
+{
+  return (left.accelMax == right.accelMax) && (left.brakeMin == right.brakeMin)
+    && (left.brakeMinCorrect == right.brakeMinCorrect) && (left.brakeMax == right.brakeMax);
+}
+
+inline bool operator==(::ad_rss::world::Dynamics const &left, ::ad_rss::world::Dynamics const &right)
+{
+  return (left.alphaLat == right.alphaLat) && (left.alphaLon == right.alphaLon)
+    && (left.lateralFluctuationMargin == right.lateralFluctuationMargin);
+}
+
+inline bool operator==(::ad_rss::situation::VehicleState const &left, ::ad_rss::situation::VehicleState const &right)
+{
+  return (left.velocity == right.velocity) && (left.dynamics == right.dynamics)
+    && (left.responseTime == right.responseTime) && (left.hasPriority == right.hasPriority)
+    && (left.isInCorrectLane == right.isInCorrectLane)
+    && (left.distanceToEnterIntersection == right.distanceToEnterIntersection)
+    && (left.distanceToLeaveIntersection == right.distanceToLeaveIntersection);
+}
+
+inline bool operator==(::ad_rss::situation::Situation const &left, ::ad_rss::situation::Situation const &right)
+{
+  return (left.timeIndex == right.timeIndex) && (left.situationId == right.situationId)
+    && (left.situationType == right.situationType) && (left.egoVehicleState == right.egoVehicleState)
+    && (left.otherVehicleState == right.otherVehicleState) && (left.relativePosition == right.relativePosition);
 }
 
 // allow compiler to search in global namespace for the above comparison operators from within gtest code

--- a/tests/test_support/wrap_new.hpp
+++ b/tests/test_support/wrap_new.hpp
@@ -28,57 +28,30 @@
 //    POSSIBILITY OF SUCH DAMAGE.
 //
 // ----------------- END LICENSE BLOCK -----------------------------------
-/**
- * @file
- */
-
 #pragma once
 
-#include "ad_rss/situation/SituationVector.hpp"
-#include "ad_rss/world/WorldModel.hpp"
-
-/*!
- * @brief namespace ad_rss
- */
-namespace ad_rss {
-
-/*!
- * @brief namespace core
- */
-namespace core {
-
-/*!
- * @brief namespace RssSituationExtraction
- *
- * Namespace providing functions required for the extraction of the RSS situations from the RSS world model.
- */
-namespace RssSituationExtraction {
+#include <cstdint>
+#include <malloc.h>
+#include <new>
 
 /**
- * @brief Extract the RSS situation of the ego vehicle and the object to be checked.
- *
- * @param [in] timeIndex - the time index of the current situation
- * @param [in] egoVehicle - the information on the ego vehicle object
- * @param [in] currentScene - the information on the object to be checked and the according lane information
- * @param [out] situation - the situation to be analyzed with RSS
- *
- * @return true if the situation could be created, false if there was an error during the operation.
+ * @brief if the counter switches to zero when new() is called,
+ * an std::bad_alloc() exception is thrown.
  */
-bool extractSituation(physics::TimeIndex const &timeIndex,
-                      world::Object const &egoVehicle,
-                      world::Scene const &currentScene,
-                      situation::Situation &situation);
+uint64_t gNewThrowCounter{0u};
 
 /**
- * @brief Extract all RSS situations to be checked from the world model.
- *
- * @param [in] worldModel - the current world model information
- * @param [out] situationVector - the vector of situations to be analyzed with RSS
- *
- * @return true if the situations could be created, false if there was an error during the operation.
+ * @brief overloading new
  */
-bool extractSituations(world::WorldModel const &worldModel, situation::SituationVector &situationVector);
-
-} // namespace RssSituationExtraction
-} // namespace core
-} // namespace ad_rss
+void *operator new(std::size_t count)
+{
+  if (gNewThrowCounter > 0u)
+  {
+    gNewThrowCounter--;
+    if (gNewThrowCounter == 0u)
+    {
+      throw std::bad_alloc();
+    }
+  }
+  return malloc(count);
+}


### PR DESCRIPTION
Fixed some doxygen warnings
Extended unit tests and fixed some discovered errors:

calculateLateralDimensions:
- hardening of operator += introduced an throw within
calculateLateralDimensions
- as result of calculateLateralDimensions() was not correctly checked in
addition, this error wasn't discovered

Extended extractSituation() to fill the timeIndex itself instead letting
extractSituations() do the task outside.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel/ad-rss-lib/7)
<!-- Reviewable:end -->
