### PR TITLE
Added missing time checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Latest changes
+* Added checks to enforce increasing time indices
+* Consider timeIndex=0 as error
 
 ## Release 1.1.0
 * Made generated files and tests more explicit by moving into respective folders

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ set(BUILD_COVERAGE "OFF" CACHE BOOL "Enable test coverage")
 
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
-project(ad-rss-lib VERSION 1.1.0)
+project(ad-rss-lib VERSION 1.2.0)
 
 set(CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_STANDARD 11)

--- a/include/ad_rss/core/RssSituationChecking.hpp
+++ b/include/ad_rss/core/RssSituationChecking.hpp
@@ -74,16 +74,6 @@ public:
   ~RssSituationChecking();
 
   /*!
-   * @brief Check if the current situation is safe.
-   *
-   * @param[in] situation      the Situation that should be analyzed
-   * @param[out] responseState the response state for the current situation
-   *
-   * @return true if situation could be analyzed, false if there was an error during evaluation
-   */
-  bool checkSituation(situation::Situation const &situation, state::ResponseState &responseState);
-
-  /*!
    * @brief Checks if the current situations are safe.
    *
    * @param [in] situationVector the vector of situations that should be analyzed
@@ -96,13 +86,31 @@ public:
 
 private:
   /*!
-   * @brief private implementation of checkSituation() with checked input range
+   * @brief Check if the current situation is safe.
    *
-   * @see checkSituation()
+   * @param[in] situation      the Situation that should be analyzed
+   * @param[in] nextTimeStep   indidicates that a new time step occurred
+   * @param[out] responseState the response state for the current situation
+   *
+   * @return true if situation could be analyzed, false if there was an error during evaluation
    */
-  bool checkSituationInputRangeChecked(situation::Situation const &situation, state::ResponseState &response);
+  bool checkSituationInputRangeChecked(situation::Situation const &situation,
+                                       bool const nextTimeStep,
+                                       state::ResponseState &responseState);
+
+  /*!
+   * @brief check to ensure situation time is consistent
+   *
+   * @param[in] situation      the Situation that should be analyzed
+   * @param[in] nextTimeStep   indidicates that a new time step occurred
+   *
+   * @return true if the time is constantly increasing
+   */
+  bool checkTimeIncreasingConsistently(situation::Situation const &situation, bool const nextTimeStep);
 
   std::unique_ptr<ad_rss::situation::RssIntersectionChecker> mIntersectionChecker;
+  physics::TimeIndex mLastTimeIndex{0u};
+  physics::TimeIndex mCurrentTimeIndex{0u};
 };
 } // namespace core
 } // namespace ad_rss

--- a/include/generated/ad_rss/situation/Situation.hpp
+++ b/include/generated/ad_rss/situation/Situation.hpp
@@ -137,7 +137,7 @@ struct Situation
    * The time index is required to distinguish different points in time when tracking states or transforming responses
    * back.
    */
-  ::ad_rss::physics::TimeIndex timeIndex;
+  ::ad_rss::physics::TimeIndex timeIndex{0u};
 
   /*!
    * The unique id of the situation.

--- a/include/generated/ad_rss/situation/SituationValidInputRange.hpp
+++ b/include/generated/ad_rss/situation/SituationValidInputRange.hpp
@@ -53,7 +53,8 @@
  *
  * \returns \c true if Situation is considered to be within the specified input range
  *
- * \note the specified input range is defined by the ranges of all members
+ * \note the specified input range is defined by the ranges of all members, plus:
+ *       ::ad_rss::physics::TimeIndex(1) <= timeIndex
  */
 inline bool withinValidInputRange(::ad_rss::situation::Situation const &input)
 {
@@ -65,7 +66,10 @@ inline bool withinValidInputRange(::ad_rss::situation::Situation const &input)
       && withinValidInputRange(input.egoVehicleState) && withinValidInputRange(input.otherVehicleState)
       && withinValidInputRange(input.relativePosition);
 
-    return membersInValidInputRange;
+    // check for individual input ranges
+    bool const timeIndexInInputRange = (::ad_rss::physics::TimeIndex(1) <= input.timeIndex);
+
+    return membersInValidInputRange && timeIndexInInputRange;
     // LCOV_EXCL_BR_STOP: not always possible to cover especially all exception branches
   }
   // LCOV_EXCL_START: not possible to cover these lines for all generated datatypes

--- a/include/generated/ad_rss/state/ResponseState.hpp
+++ b/include/generated/ad_rss/state/ResponseState.hpp
@@ -130,7 +130,7 @@ struct ResponseState
    * The time index is required to distinguish different points in time when tracking states or transforming responses
    * back.
    */
-  ::ad_rss::physics::TimeIndex timeIndex;
+  ::ad_rss::physics::TimeIndex timeIndex{0u};
 
   /*!
    * Id of the situation this state refers to.

--- a/include/generated/ad_rss/state/ResponseStateValidInputRange.hpp
+++ b/include/generated/ad_rss/state/ResponseStateValidInputRange.hpp
@@ -52,7 +52,8 @@
  *
  * \returns \c true if ResponseState is considered to be within the specified input range
  *
- * \note the specified input range is defined by the ranges of all members
+ * \note the specified input range is defined by the ranges of all members, plus:
+ *       ::ad_rss::physics::TimeIndex(1) <= timeIndex
  */
 inline bool withinValidInputRange(::ad_rss::state::ResponseState const &input)
 {
@@ -63,7 +64,10 @@ inline bool withinValidInputRange(::ad_rss::state::ResponseState const &input)
     bool const membersInValidInputRange = withinValidInputRange(input.longitudinalState)
       && withinValidInputRange(input.lateralStateRight) && withinValidInputRange(input.lateralStateLeft);
 
-    return membersInValidInputRange;
+    // check for individual input ranges
+    bool const timeIndexInInputRange = (::ad_rss::physics::TimeIndex(1) <= input.timeIndex);
+
+    return membersInValidInputRange && timeIndexInInputRange;
     // LCOV_EXCL_BR_STOP: not always possible to cover especially all exception branches
   }
   // LCOV_EXCL_START: not possible to cover these lines for all generated datatypes

--- a/include/generated/ad_rss/world/AccelerationRestrictionValidInputRange.hpp
+++ b/include/generated/ad_rss/world/AccelerationRestrictionValidInputRange.hpp
@@ -51,7 +51,8 @@
  *
  * \returns \c true if AccelerationRestriction is considered to be within the specified input range
  *
- * \note the specified input range is defined by the ranges of all members
+ * \note the specified input range is defined by the ranges of all members, plus:
+ *       ::ad_rss::physics::TimeIndex(1) <= timeIndex
  */
 inline bool withinValidInputRange(::ad_rss::world::AccelerationRestriction const &input)
 {
@@ -62,7 +63,10 @@ inline bool withinValidInputRange(::ad_rss::world::AccelerationRestriction const
     bool const membersInValidInputRange = withinValidInputRange(input.lateralLeftRange)
       && withinValidInputRange(input.longitudinalRange) && withinValidInputRange(input.lateralRightRange);
 
-    return membersInValidInputRange;
+    // check for individual input ranges
+    bool const timeIndexInInputRange = (::ad_rss::physics::TimeIndex(1) <= input.timeIndex);
+
+    return membersInValidInputRange && timeIndexInInputRange;
     // LCOV_EXCL_BR_STOP: not always possible to cover especially all exception branches
   }
   // LCOV_EXCL_START: not possible to cover these lines for all generated datatypes

--- a/include/generated/ad_rss/world/RoadSegmentValidInputRange.hpp
+++ b/include/generated/ad_rss/world/RoadSegmentValidInputRange.hpp
@@ -52,7 +52,7 @@
  * \returns \c true if RoadSegment is considered to be within the specified input range
  *
  * \note the specified input range is defined by
- *       0 <= \c input.size() <= 1000
+ *       1 <= \c input.size() <= 1000
  *       and the ranges of all vector elements
  */
 inline bool withinValidInputRange(::ad_rss::world::RoadSegment const &input)
@@ -60,7 +60,7 @@ inline bool withinValidInputRange(::ad_rss::world::RoadSegment const &input)
   try
   {
     // LCOV_EXCL_BR_START: not always possible to cover especially all exception branches
-    bool inValidInputRange = (input.size() <= std::size_t(1000));
+    bool inValidInputRange = ((std::size_t(1)) <= input.size()) && (input.size() <= std::size_t(1000));
 
     if (inValidInputRange)
     {

--- a/include/generated/ad_rss/world/WorldModelValidInputRange.hpp
+++ b/include/generated/ad_rss/world/WorldModelValidInputRange.hpp
@@ -52,7 +52,8 @@
  *
  * \returns \c true if WorldModel is considered to be within the specified input range
  *
- * \note the specified input range is defined by the ranges of all members
+ * \note the specified input range is defined by the ranges of all members, plus:
+ *       ::ad_rss::physics::TimeIndex(1) <= timeIndex
  */
 inline bool withinValidInputRange(::ad_rss::world::WorldModel const &input)
 {
@@ -63,7 +64,10 @@ inline bool withinValidInputRange(::ad_rss::world::WorldModel const &input)
     bool const membersInValidInputRange
       = withinValidInputRange(input.egoVehicle) && withinValidInputRange(input.scenes);
 
-    return membersInValidInputRange;
+    // check for individual input ranges
+    bool const timeIndexInInputRange = (::ad_rss::physics::TimeIndex(1) <= input.timeIndex);
+
+    return membersInValidInputRange && timeIndexInInputRange;
     // LCOV_EXCL_BR_STOP: not always possible to cover especially all exception branches
   }
   // LCOV_EXCL_START: not possible to cover these lines for all generated datatypes

--- a/src/core/RssSituationChecking.cpp
+++ b/src/core/RssSituationChecking.cpp
@@ -180,7 +180,7 @@ bool RssSituationChecking::checkTimeIncreasingConsistently(situation::Situation 
   }
   else
   {
-    // check for overrun
+    // check for overflow
     physics::TimeIndex const deltaTimeIndex = mCurrentTimeIndex - mLastTimeIndex;
     if (deltaTimeIndex < (std::numeric_limits<physics::TimeIndex>::max() / 2))
     {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,6 +38,17 @@ set(EXEC_NAME ad-rss-tests)
 
 include(generated/CMakeLists.txt)
 
+set(RSS_TEST_SOURCES_WITH_PRIVATE_ACCESS
+  situation/RssSituationCheckingInputRangeTests.cpp
+  situation/RssSituationCheckingTestsIntersectionInputRangeTests.cpp
+  situation/RssSituationCheckingTestsIntersectionNoPriority.cpp
+  situation/RssSituationCheckingTestsIntersectionPriority.cpp
+  situation/RssSituationCheckingTestsLongitudinal.cpp
+  situation/RssSituationCheckingTestsLateral.cpp
+  situation/RssSituationCheckingTestsOppositeDirection.cpp
+  situation/RssSituationCheckingTestsNotRelevant.cpp
+)
+
 set(RSS_TEST_SOURCES
   core/RssCheckTests.cpp
   core/RssCheckSameDirectionTests.cpp
@@ -62,21 +73,13 @@ set(RSS_TEST_SOURCES
   situation/RSSFormulaTestsCalculateSafeLateralDistance.cpp
   situation/RSSFormulaTestsCalculateSafeLongitudinalDistanceSameDirection.cpp
   situation/RSSFormulaTestsInputRangeChecks.cpp
-  situation/RssSituationCheckingInputRangeTests.cpp
-  situation/RssSituationCheckingTestsIntersectionInputRangeTests.cpp
-  situation/RssSituationCheckingTestsIntersectionNoPriority.cpp
-  situation/RssSituationCheckingTestsIntersectionPriority.cpp
-  situation/RssSituationCheckingTestsLongitudinal.cpp
-  situation/RssSituationCheckingTestsLateral.cpp
-  situation/RssSituationCheckingTestsOppositeDirection.cpp
-  situation/RssSituationCheckingTestsNotRelevant.cpp
   situation/VehicleTests.cpp
   test_support/wrap_new.cpp
+  ${RSS_TEST_SOURCES_WITH_PRIVATE_ACCESS}
   ${GENERATED_TEST_SOURCES}
 )
 
-set_source_files_properties(situation/RssSituationCheckingInputRangeTests.cpp PROPERITES COMPILE_FLAGS -fno-access-control)
-set_source_files_properties(situation/RssSituationCheckingTestsIntersectionInputRangeTests.cpp PROPERITES COMPILE_FLAGS -fno-access-control)
+set_source_files_properties(${RSS_TEST_SOURCES_WITH_PRIVATE_ACCESS} PROPERITES COMPILE_FLAGS -fno-access-control)
 
 
 add_executable(${EXEC_NAME} ${RSS_TEST_SOURCES})

--- a/tests/core/RssCheckIntersectionTests.cpp
+++ b/tests/core/RssCheckIntersectionTests.cpp
@@ -59,9 +59,9 @@ protected:
       worldModel.egoVehicle.occupiedRegions[0].segmentId = egoVehicleSegmentId;
       for (uint32_t i = 0; i <= 90; i++)
       {
-        worldModel.timeIndex = i;
         worldModel.egoVehicle.occupiedRegions[0].lonRange.minimum = ParametricValue(0.01 * i);
         worldModel.egoVehicle.occupiedRegions[0].lonRange.maximum = ParametricValue(0.01 * i + 0.1);
+        worldModel.timeIndex++;
 
         ASSERT_TRUE(rssCheck.calculateAccelerationRestriction(worldModel, accelerationRestriction));
 

--- a/tests/core/RssCheckLateralTests.cpp
+++ b/tests/core/RssCheckLateralTests.cpp
@@ -65,6 +65,7 @@ TEST_F(RssCheckLateralEgoRightTest, Lateral_Velocity_Towards_Each_Other)
   {
     worldModel.egoVehicle.occupiedRegions[0].latRange.maximum = ParametricValue(1 - (0.01 * i));
     worldModel.egoVehicle.occupiedRegions[0].latRange.minimum = ParametricValue(1 - (0.01 * i + 0.1));
+    worldModel.timeIndex++;
 
     Distance const dMin = calculateLateralMinSafeDistance(worldModel.scenes[0].object, worldModel.egoVehicle);
 
@@ -95,6 +96,7 @@ TEST_F(RssCheckLateralEgoRightTest, No_Lateral_Velocity)
   {
     worldModel.egoVehicle.occupiedRegions[0].latRange.minimum = ParametricValue(0.01 * i);
     worldModel.egoVehicle.occupiedRegions[0].latRange.maximum = ParametricValue(0.01 * i + 0.1);
+    worldModel.timeIndex++;
 
     ASSERT_TRUE(rssCheck.calculateAccelerationRestriction(worldModel, accelerationRestriction));
 
@@ -114,6 +116,7 @@ TEST_F(RssCheckLateralEgoRightTest, Lateral_Velocity_Aways_From_Each_Other)
   {
     worldModel.egoVehicle.occupiedRegions[0].latRange.maximum = ParametricValue(1 - (0.01 * i));
     worldModel.egoVehicle.occupiedRegions[0].latRange.minimum = ParametricValue(1 - (0.01 * i + 0.1));
+    worldModel.timeIndex++;
 
     ASSERT_TRUE(rssCheck.calculateAccelerationRestriction(worldModel, accelerationRestriction));
 
@@ -152,6 +155,7 @@ TEST_F(RssCheckLateralEgoLeftTest, Lateral_Velocity_Towards_Each_Other)
   {
     worldModel.egoVehicle.occupiedRegions[0].latRange.minimum = ParametricValue(0.01 * i);
     worldModel.egoVehicle.occupiedRegions[0].latRange.maximum = ParametricValue(0.01 * i + 0.1);
+    worldModel.timeIndex++;
 
     Distance const dMin = calculateLateralMinSafeDistance(worldModel.egoVehicle, worldModel.scenes[0].object);
 

--- a/tests/core/RssCheckOppositeDirectionTests.cpp
+++ b/tests/core/RssCheckOppositeDirectionTests.cpp
@@ -93,6 +93,7 @@ TEST_F(RssCheckOppositeDirectionEgoCorrectTest, DifferentVelocities_NoLateralCon
   for (uint32_t i = 0; i < 100; i++)
   {
     worldModel.egoVehicle.velocity.speedLon = kmhToMeterPerSec(i);
+    worldModel.timeIndex++;
 
     ASSERT_TRUE(rssCheck.calculateAccelerationRestriction(worldModel, accelerationRestriction));
 

--- a/tests/core/RssCheckSameDirectionTests.cpp
+++ b/tests/core/RssCheckSameDirectionTests.cpp
@@ -104,6 +104,7 @@ TEST_F(RssCheckSameDirectionOtherLeadingTest, DifferentVelocities_NoLateralConfl
   for (uint32_t i = 0; i < 100; i++)
   {
     worldModel.egoVehicle.velocity.speedLon = kmhToMeterPerSec(i);
+    worldModel.timeIndex++;
 
     ASSERT_TRUE(rssCheck.calculateAccelerationRestriction(worldModel, accelerationRestriction));
 
@@ -128,6 +129,7 @@ TEST_F(RssCheckSameDirectionOtherLeadingTest, _DifferentVelocities_NoLateralConf
   for (uint32_t i = 0; i < 100; i++)
   {
     worldModel.egoVehicle.velocity.speedLon = kmhToMeterPerSec(i);
+    worldModel.timeIndex++;
 
     ASSERT_TRUE(rssCheck.calculateAccelerationRestriction(worldModel, accelerationRestriction));
 
@@ -145,6 +147,7 @@ TEST_F(RssCheckSameDirectionEgoLeadingTest, DifferentVelocities)
   for (uint32_t i = 0; i < 100; i++)
   {
     worldModel.scenes[0].object.velocity.speedLon = kmhToMeterPerSec(i);
+    worldModel.timeIndex++;
 
     ASSERT_TRUE(rssCheck.calculateAccelerationRestriction(worldModel, accelerationRestriction));
 
@@ -169,6 +172,7 @@ TEST_F(RssCheckSameDirectionEgoLeadingTest, Overlap_Front)
   for (uint32_t i = 0; i < 100; i++)
   {
     worldModel.scenes[0].object.velocity.speedLon = kmhToMeterPerSec(i);
+    worldModel.timeIndex++;
 
     ASSERT_TRUE(rssCheck.calculateAccelerationRestriction(worldModel, accelerationRestriction));
 
@@ -193,6 +197,7 @@ TEST_F(RssCheckSameDirectionEgoLeadingTest, Overlap_Right)
   for (uint32_t i = 0; i < 100; i++)
   {
     worldModel.scenes[0].object.velocity.speedLon = kmhToMeterPerSec(i);
+    worldModel.timeIndex++;
 
     ASSERT_TRUE(rssCheck.calculateAccelerationRestriction(worldModel, accelerationRestriction));
 
@@ -217,6 +222,7 @@ TEST_F(RssCheckSameDirectionEgoLeadingTest, Overlap_Left)
   for (uint32_t i = 0; i < 100; i++)
   {
     worldModel.scenes[0].object.velocity.speedLon = kmhToMeterPerSec(i);
+    worldModel.timeIndex++;
 
     ASSERT_TRUE(rssCheck.calculateAccelerationRestriction(worldModel, accelerationRestriction));
 

--- a/tests/core/RssCheckTestBaseT.hpp
+++ b/tests/core/RssCheckTestBaseT.hpp
@@ -499,6 +499,7 @@ protected:
     for (uint32_t i = 0; i < 100; i++)
     {
       worldModel.egoVehicle.velocity.speedLon = kmhToMeterPerSec(i);
+      worldModel.timeIndex++;
 
       ASSERT_TRUE(rssCheck.calculateAccelerationRestriction(worldModel, accelerationRestriction));
 
@@ -522,6 +523,7 @@ protected:
     {
       worldModel.egoVehicle.occupiedRegions[0].lonRange.minimum = ParametricValue(0.01 * i);
       worldModel.egoVehicle.occupiedRegions[0].lonRange.maximum = ParametricValue(0.01 * i + 0.1);
+      worldModel.timeIndex++;
 
       ASSERT_TRUE(rssCheck.calculateAccelerationRestriction(worldModel, accelerationRestriction));
 

--- a/tests/core/RssResponseTransformationTests.cpp
+++ b/tests/core/RssResponseTransformationTests.cpp
@@ -65,6 +65,12 @@ TEST_F(RssResponseTransformationTests, invalidTimeStamp)
 
   ASSERT_FALSE(::ad_rss::core::RssResponseTransformation::transformProperResponse(
     worldModel, responseState, accelerationRestriction));
+
+  worldModel.timeIndex = 0u;
+  responseState.timeIndex = 1u;
+
+  ASSERT_FALSE(::ad_rss::core::RssResponseTransformation::transformProperResponse(
+    worldModel, responseState, accelerationRestriction));
 }
 
 TEST_F(RssResponseTransformationTests, invalidLongitudinalResponseState)

--- a/tests/core/RssSituationExtractionIntersectionTests.cpp
+++ b/tests/core/RssSituationExtractionIntersectionTests.cpp
@@ -126,7 +126,7 @@ TEST_F(RssSituationExtractionIntersectionTests, noLongitudinalDifference)
   }
 
   worldModel.scenes.push_back(scene);
-  worldModel.timeIndex = 0;
+  worldModel.timeIndex = 1;
 
   ASSERT_TRUE(extractSituations(worldModel, situationVector));
   ASSERT_EQ(situationVector.size(), 1);
@@ -199,7 +199,7 @@ TEST_F(RssSituationExtractionIntersectionTests, longitudinalDifference)
   }
 
   worldModel.scenes.push_back(scene);
-  worldModel.timeIndex = 0;
+  worldModel.timeIndex = 1;
 
   ASSERT_TRUE(extractSituations(worldModel, situationVector));
   ASSERT_EQ(situationVector.size(), 1);

--- a/tests/core/RssSituationExtractionOppositeDirectionTests.cpp
+++ b/tests/core/RssSituationExtractionOppositeDirectionTests.cpp
@@ -105,7 +105,7 @@ TEST_F(RssSituationExtractionOppositeDirectionTests, noLongitudinalDifference)
   scene.egoVehicleRoad.push_back(roadSegment);
 
   worldModel.scenes.push_back(scene);
-  worldModel.timeIndex = 0;
+  worldModel.timeIndex = 1;
 
   ASSERT_TRUE(extractSituations(worldModel, situationVector));
   ASSERT_EQ(situationVector.size(), 1);
@@ -146,7 +146,7 @@ TEST_F(RssSituationExtractionOppositeDirectionTests, longitudinalDifference)
   scene.egoVehicleRoad.push_back(roadSegment);
 
   worldModel.scenes.push_back(scene);
-  worldModel.timeIndex = 0;
+  worldModel.timeIndex = 1;
 
   ASSERT_TRUE(extractSituations(worldModel, situationVector));
   ASSERT_EQ(situationVector.size(), 1);

--- a/tests/core/RssSituationExtractionSameDirectionTests.cpp
+++ b/tests/core/RssSituationExtractionSameDirectionTests.cpp
@@ -104,7 +104,7 @@ TEST_F(RssSituationExtractionSameDirectionTests, noLongitudinalDifference)
 
   scene.egoVehicleRoad.push_back(roadSegment);
   worldModel.scenes.push_back(scene);
-  worldModel.timeIndex = 0;
+  worldModel.timeIndex = 1;
 
   ASSERT_TRUE(extractSituations(worldModel, situationVector));
   ASSERT_EQ(situationVector.size(), 1);
@@ -145,7 +145,7 @@ TEST_F(RssSituationExtractionSameDirectionTests, longitudinalDifferenceEgoLeadin
 
   scene.egoVehicleRoad.push_back(roadSegment);
   worldModel.scenes.push_back(scene);
-  worldModel.timeIndex = 0;
+  worldModel.timeIndex = 1;
 
   ASSERT_TRUE(extractSituations(worldModel, situationVector));
   ASSERT_EQ(situationVector.size(), 1);
@@ -185,7 +185,7 @@ TEST_F(RssSituationExtractionSameDirectionTests, longitudinalDifferenceEgoFollow
 
   scene.egoVehicleRoad.push_back(roadSegment);
   worldModel.scenes.push_back(scene);
-  worldModel.timeIndex = 0;
+  worldModel.timeIndex = 1;
 
   ASSERT_TRUE(extractSituations(worldModel, situationVector));
   ASSERT_EQ(situationVector.size(), 1);

--- a/tests/generated/situation/SituationTests.cpp
+++ b/tests/generated/situation/SituationTests.cpp
@@ -47,6 +47,7 @@ protected:
     // valid initialization
     ::ad_rss::situation::Situation value;
     ::ad_rss::physics::TimeIndex valueTimeIndex(std::numeric_limits<::ad_rss::physics::TimeIndex>::lowest());
+    valueTimeIndex = ::ad_rss::physics::TimeIndex(1); // set to valid value within struct
     value.timeIndex = valueTimeIndex;
     ::ad_rss::situation::SituationId valueSituationId(std::numeric_limits<::ad_rss::situation::SituationId>::lowest());
     value.situationId = valueSituationId;

--- a/tests/generated/situation/SituationValidInputRangeTests.cpp
+++ b/tests/generated/situation/SituationValidInputRangeTests.cpp
@@ -45,6 +45,7 @@ TEST(SituationValidInputRangeTests, testValidInputRange)
 {
   ::ad_rss::situation::Situation value;
   ::ad_rss::physics::TimeIndex valueTimeIndex(std::numeric_limits<::ad_rss::physics::TimeIndex>::lowest());
+  valueTimeIndex = ::ad_rss::physics::TimeIndex(1); // set to valid value within struct
   value.timeIndex = valueTimeIndex;
   ::ad_rss::situation::SituationId valueSituationId(std::numeric_limits<::ad_rss::situation::SituationId>::lowest());
   value.situationId = valueSituationId;
@@ -181,6 +182,7 @@ TEST(SituationValidInputRangeTests, testValidInputRangeSituationTypeTooSmall)
 {
   ::ad_rss::situation::Situation value;
   ::ad_rss::physics::TimeIndex valueTimeIndex(std::numeric_limits<::ad_rss::physics::TimeIndex>::lowest());
+  valueTimeIndex = ::ad_rss::physics::TimeIndex(1); // set to valid value within struct
   value.timeIndex = valueTimeIndex;
   ::ad_rss::situation::SituationId valueSituationId(std::numeric_limits<::ad_rss::situation::SituationId>::lowest());
   value.situationId = valueSituationId;
@@ -321,6 +323,7 @@ TEST(SituationValidInputRangeTests, testValidInputRangeSituationTypeTooBig)
 {
   ::ad_rss::situation::Situation value;
   ::ad_rss::physics::TimeIndex valueTimeIndex(std::numeric_limits<::ad_rss::physics::TimeIndex>::lowest());
+  valueTimeIndex = ::ad_rss::physics::TimeIndex(1); // set to valid value within struct
   value.timeIndex = valueTimeIndex;
   ::ad_rss::situation::SituationId valueSituationId(std::numeric_limits<::ad_rss::situation::SituationId>::lowest());
   value.situationId = valueSituationId;
@@ -461,6 +464,7 @@ TEST(SituationValidInputRangeTests, testValidInputRangeEgoVehicleStateTooSmall)
 {
   ::ad_rss::situation::Situation value;
   ::ad_rss::physics::TimeIndex valueTimeIndex(std::numeric_limits<::ad_rss::physics::TimeIndex>::lowest());
+  valueTimeIndex = ::ad_rss::physics::TimeIndex(1); // set to valid value within struct
   value.timeIndex = valueTimeIndex;
   ::ad_rss::situation::SituationId valueSituationId(std::numeric_limits<::ad_rss::situation::SituationId>::lowest());
   value.situationId = valueSituationId;
@@ -605,6 +609,7 @@ TEST(SituationValidInputRangeTests, testValidInputRangeEgoVehicleStateTooBig)
 {
   ::ad_rss::situation::Situation value;
   ::ad_rss::physics::TimeIndex valueTimeIndex(std::numeric_limits<::ad_rss::physics::TimeIndex>::lowest());
+  valueTimeIndex = ::ad_rss::physics::TimeIndex(1); // set to valid value within struct
   value.timeIndex = valueTimeIndex;
   ::ad_rss::situation::SituationId valueSituationId(std::numeric_limits<::ad_rss::situation::SituationId>::lowest());
   value.situationId = valueSituationId;
@@ -749,6 +754,7 @@ TEST(SituationValidInputRangeTests, testValidInputRangeOtherVehicleStateTooSmall
 {
   ::ad_rss::situation::Situation value;
   ::ad_rss::physics::TimeIndex valueTimeIndex(std::numeric_limits<::ad_rss::physics::TimeIndex>::lowest());
+  valueTimeIndex = ::ad_rss::physics::TimeIndex(1); // set to valid value within struct
   value.timeIndex = valueTimeIndex;
   ::ad_rss::situation::SituationId valueSituationId(std::numeric_limits<::ad_rss::situation::SituationId>::lowest());
   value.situationId = valueSituationId;
@@ -893,6 +899,7 @@ TEST(SituationValidInputRangeTests, testValidInputRangeOtherVehicleStateTooBig)
 {
   ::ad_rss::situation::Situation value;
   ::ad_rss::physics::TimeIndex valueTimeIndex(std::numeric_limits<::ad_rss::physics::TimeIndex>::lowest());
+  valueTimeIndex = ::ad_rss::physics::TimeIndex(1); // set to valid value within struct
   value.timeIndex = valueTimeIndex;
   ::ad_rss::situation::SituationId valueSituationId(std::numeric_limits<::ad_rss::situation::SituationId>::lowest());
   value.situationId = valueSituationId;
@@ -1037,6 +1044,7 @@ TEST(SituationValidInputRangeTests, testValidInputRangeRelativePositionTooSmall)
 {
   ::ad_rss::situation::Situation value;
   ::ad_rss::physics::TimeIndex valueTimeIndex(std::numeric_limits<::ad_rss::physics::TimeIndex>::lowest());
+  valueTimeIndex = ::ad_rss::physics::TimeIndex(1); // set to valid value within struct
   value.timeIndex = valueTimeIndex;
   ::ad_rss::situation::SituationId valueSituationId(std::numeric_limits<::ad_rss::situation::SituationId>::lowest());
   value.situationId = valueSituationId;
@@ -1180,6 +1188,7 @@ TEST(SituationValidInputRangeTests, testValidInputRangeRelativePositionTooBig)
 {
   ::ad_rss::situation::Situation value;
   ::ad_rss::physics::TimeIndex valueTimeIndex(std::numeric_limits<::ad_rss::physics::TimeIndex>::lowest());
+  valueTimeIndex = ::ad_rss::physics::TimeIndex(1); // set to valid value within struct
   value.timeIndex = valueTimeIndex;
   ::ad_rss::situation::SituationId valueSituationId(std::numeric_limits<::ad_rss::situation::SituationId>::lowest());
   value.situationId = valueSituationId;

--- a/tests/generated/situation/SituationVectorValidInputRangeTests.cpp
+++ b/tests/generated/situation/SituationVectorValidInputRangeTests.cpp
@@ -52,6 +52,7 @@ TEST(SituationVectorValidInputRangeTests, testValidInputRangeValidInputRangeMax)
   ::ad_rss::situation::SituationVector value;
   ::ad_rss::situation::Situation element;
   ::ad_rss::physics::TimeIndex elementTimeIndex(std::numeric_limits<::ad_rss::physics::TimeIndex>::lowest());
+  elementTimeIndex = ::ad_rss::physics::TimeIndex(1); // set to valid value within struct
   element.timeIndex = elementTimeIndex;
   ::ad_rss::situation::SituationId elementSituationId(std::numeric_limits<::ad_rss::situation::SituationId>::lowest());
   element.situationId = elementSituationId;
@@ -190,6 +191,7 @@ TEST(SituationVectorValidInputRangeTests, testValidInputRangeHigherThanInputRang
   ::ad_rss::situation::SituationVector value;
   ::ad_rss::situation::Situation element;
   ::ad_rss::physics::TimeIndex elementTimeIndex(std::numeric_limits<::ad_rss::physics::TimeIndex>::lowest());
+  elementTimeIndex = ::ad_rss::physics::TimeIndex(1); // set to valid value within struct
   element.timeIndex = elementTimeIndex;
   ::ad_rss::situation::SituationId elementSituationId(std::numeric_limits<::ad_rss::situation::SituationId>::lowest());
   element.situationId = elementSituationId;

--- a/tests/generated/state/ResponseStateTests.cpp
+++ b/tests/generated/state/ResponseStateTests.cpp
@@ -47,6 +47,7 @@ protected:
     // valid initialization
     ::ad_rss::state::ResponseState value;
     ::ad_rss::physics::TimeIndex valueTimeIndex(std::numeric_limits<::ad_rss::physics::TimeIndex>::lowest());
+    valueTimeIndex = ::ad_rss::physics::TimeIndex(1); // set to valid value within struct
     value.timeIndex = valueTimeIndex;
     ::ad_rss::situation::SituationId valueSituationId(std::numeric_limits<::ad_rss::situation::SituationId>::lowest());
     value.situationId = valueSituationId;

--- a/tests/generated/state/ResponseStateValidInputRangeTests.cpp
+++ b/tests/generated/state/ResponseStateValidInputRangeTests.cpp
@@ -45,6 +45,7 @@ TEST(ResponseStateValidInputRangeTests, testValidInputRange)
 {
   ::ad_rss::state::ResponseState value;
   ::ad_rss::physics::TimeIndex valueTimeIndex(std::numeric_limits<::ad_rss::physics::TimeIndex>::lowest());
+  valueTimeIndex = ::ad_rss::physics::TimeIndex(1); // set to valid value within struct
   value.timeIndex = valueTimeIndex;
   ::ad_rss::situation::SituationId valueSituationId(std::numeric_limits<::ad_rss::situation::SituationId>::lowest());
   value.situationId = valueSituationId;
@@ -73,6 +74,7 @@ TEST(ResponseStateValidInputRangeTests, testValidInputRangeLongitudinalStateTooS
 {
   ::ad_rss::state::ResponseState value;
   ::ad_rss::physics::TimeIndex valueTimeIndex(std::numeric_limits<::ad_rss::physics::TimeIndex>::lowest());
+  valueTimeIndex = ::ad_rss::physics::TimeIndex(1); // set to valid value within struct
   value.timeIndex = valueTimeIndex;
   ::ad_rss::situation::SituationId valueSituationId(std::numeric_limits<::ad_rss::situation::SituationId>::lowest());
   value.situationId = valueSituationId;
@@ -108,6 +110,7 @@ TEST(ResponseStateValidInputRangeTests, testValidInputRangeLongitudinalStateTooB
 {
   ::ad_rss::state::ResponseState value;
   ::ad_rss::physics::TimeIndex valueTimeIndex(std::numeric_limits<::ad_rss::physics::TimeIndex>::lowest());
+  valueTimeIndex = ::ad_rss::physics::TimeIndex(1); // set to valid value within struct
   value.timeIndex = valueTimeIndex;
   ::ad_rss::situation::SituationId valueSituationId(std::numeric_limits<::ad_rss::situation::SituationId>::lowest());
   value.situationId = valueSituationId;
@@ -143,6 +146,7 @@ TEST(ResponseStateValidInputRangeTests, testValidInputRangeLateralStateRightTooS
 {
   ::ad_rss::state::ResponseState value;
   ::ad_rss::physics::TimeIndex valueTimeIndex(std::numeric_limits<::ad_rss::physics::TimeIndex>::lowest());
+  valueTimeIndex = ::ad_rss::physics::TimeIndex(1); // set to valid value within struct
   value.timeIndex = valueTimeIndex;
   ::ad_rss::situation::SituationId valueSituationId(std::numeric_limits<::ad_rss::situation::SituationId>::lowest());
   value.situationId = valueSituationId;
@@ -177,6 +181,7 @@ TEST(ResponseStateValidInputRangeTests, testValidInputRangeLateralStateRightTooB
 {
   ::ad_rss::state::ResponseState value;
   ::ad_rss::physics::TimeIndex valueTimeIndex(std::numeric_limits<::ad_rss::physics::TimeIndex>::lowest());
+  valueTimeIndex = ::ad_rss::physics::TimeIndex(1); // set to valid value within struct
   value.timeIndex = valueTimeIndex;
   ::ad_rss::situation::SituationId valueSituationId(std::numeric_limits<::ad_rss::situation::SituationId>::lowest());
   value.situationId = valueSituationId;
@@ -211,6 +216,7 @@ TEST(ResponseStateValidInputRangeTests, testValidInputRangeLateralStateLeftTooSm
 {
   ::ad_rss::state::ResponseState value;
   ::ad_rss::physics::TimeIndex valueTimeIndex(std::numeric_limits<::ad_rss::physics::TimeIndex>::lowest());
+  valueTimeIndex = ::ad_rss::physics::TimeIndex(1); // set to valid value within struct
   value.timeIndex = valueTimeIndex;
   ::ad_rss::situation::SituationId valueSituationId(std::numeric_limits<::ad_rss::situation::SituationId>::lowest());
   value.situationId = valueSituationId;
@@ -245,6 +251,7 @@ TEST(ResponseStateValidInputRangeTests, testValidInputRangeLateralStateLeftTooBi
 {
   ::ad_rss::state::ResponseState value;
   ::ad_rss::physics::TimeIndex valueTimeIndex(std::numeric_limits<::ad_rss::physics::TimeIndex>::lowest());
+  valueTimeIndex = ::ad_rss::physics::TimeIndex(1); // set to valid value within struct
   value.timeIndex = valueTimeIndex;
   ::ad_rss::situation::SituationId valueSituationId(std::numeric_limits<::ad_rss::situation::SituationId>::lowest());
   value.situationId = valueSituationId;

--- a/tests/generated/state/ResponseStateVectorValidInputRangeTests.cpp
+++ b/tests/generated/state/ResponseStateVectorValidInputRangeTests.cpp
@@ -52,6 +52,7 @@ TEST(ResponseStateVectorValidInputRangeTests, testValidInputRangeValidInputRange
   ::ad_rss::state::ResponseStateVector value;
   ::ad_rss::state::ResponseState element;
   ::ad_rss::physics::TimeIndex elementTimeIndex(std::numeric_limits<::ad_rss::physics::TimeIndex>::lowest());
+  elementTimeIndex = ::ad_rss::physics::TimeIndex(1); // set to valid value within struct
   element.timeIndex = elementTimeIndex;
   ::ad_rss::situation::SituationId elementSituationId(std::numeric_limits<::ad_rss::situation::SituationId>::lowest());
   element.situationId = elementSituationId;
@@ -82,6 +83,7 @@ TEST(ResponseStateVectorValidInputRangeTests, testValidInputRangeHigherThanInput
   ::ad_rss::state::ResponseStateVector value;
   ::ad_rss::state::ResponseState element;
   ::ad_rss::physics::TimeIndex elementTimeIndex(std::numeric_limits<::ad_rss::physics::TimeIndex>::lowest());
+  elementTimeIndex = ::ad_rss::physics::TimeIndex(1); // set to valid value within struct
   element.timeIndex = elementTimeIndex;
   ::ad_rss::situation::SituationId elementSituationId(std::numeric_limits<::ad_rss::situation::SituationId>::lowest());
   element.situationId = elementSituationId;

--- a/tests/generated/world/AccelerationRestrictionTests.cpp
+++ b/tests/generated/world/AccelerationRestrictionTests.cpp
@@ -47,6 +47,7 @@ protected:
     // valid initialization
     ::ad_rss::world::AccelerationRestriction value;
     ::ad_rss::physics::TimeIndex valueTimeIndex(std::numeric_limits<::ad_rss::physics::TimeIndex>::lowest());
+    valueTimeIndex = ::ad_rss::physics::TimeIndex(1); // set to valid value within struct
     value.timeIndex = valueTimeIndex;
     ::ad_rss::physics::AccelerationRange valueLateralLeftRange;
     ::ad_rss::physics::Acceleration valueLateralLeftRangeMinimum(-1e2);

--- a/tests/generated/world/AccelerationRestrictionValidInputRangeTests.cpp
+++ b/tests/generated/world/AccelerationRestrictionValidInputRangeTests.cpp
@@ -45,6 +45,7 @@ TEST(AccelerationRestrictionValidInputRangeTests, testValidInputRange)
 {
   ::ad_rss::world::AccelerationRestriction value;
   ::ad_rss::physics::TimeIndex valueTimeIndex(std::numeric_limits<::ad_rss::physics::TimeIndex>::lowest());
+  valueTimeIndex = ::ad_rss::physics::TimeIndex(1); // set to valid value within struct
   value.timeIndex = valueTimeIndex;
   ::ad_rss::physics::AccelerationRange valueLateralLeftRange;
   ::ad_rss::physics::Acceleration valueLateralLeftRangeMinimum(-1e2);
@@ -77,6 +78,7 @@ TEST(AccelerationRestrictionValidInputRangeTests, testValidInputRangeLateralLeft
 {
   ::ad_rss::world::AccelerationRestriction value;
   ::ad_rss::physics::TimeIndex valueTimeIndex(std::numeric_limits<::ad_rss::physics::TimeIndex>::lowest());
+  valueTimeIndex = ::ad_rss::physics::TimeIndex(1); // set to valid value within struct
   value.timeIndex = valueTimeIndex;
   ::ad_rss::physics::AccelerationRange valueLateralLeftRange;
   ::ad_rss::physics::Acceleration valueLateralLeftRangeMinimum(-1e2);
@@ -115,6 +117,7 @@ TEST(AccelerationRestrictionValidInputRangeTests, testValidInputRangeLateralLeft
 {
   ::ad_rss::world::AccelerationRestriction value;
   ::ad_rss::physics::TimeIndex valueTimeIndex(std::numeric_limits<::ad_rss::physics::TimeIndex>::lowest());
+  valueTimeIndex = ::ad_rss::physics::TimeIndex(1); // set to valid value within struct
   value.timeIndex = valueTimeIndex;
   ::ad_rss::physics::AccelerationRange valueLateralLeftRange;
   ::ad_rss::physics::Acceleration valueLateralLeftRangeMinimum(-1e2);
@@ -153,6 +156,7 @@ TEST(AccelerationRestrictionValidInputRangeTests, testValidInputRangeLongitudina
 {
   ::ad_rss::world::AccelerationRestriction value;
   ::ad_rss::physics::TimeIndex valueTimeIndex(std::numeric_limits<::ad_rss::physics::TimeIndex>::lowest());
+  valueTimeIndex = ::ad_rss::physics::TimeIndex(1); // set to valid value within struct
   value.timeIndex = valueTimeIndex;
   ::ad_rss::physics::AccelerationRange valueLateralLeftRange;
   ::ad_rss::physics::Acceleration valueLateralLeftRangeMinimum(-1e2);
@@ -191,6 +195,7 @@ TEST(AccelerationRestrictionValidInputRangeTests, testValidInputRangeLongitudina
 {
   ::ad_rss::world::AccelerationRestriction value;
   ::ad_rss::physics::TimeIndex valueTimeIndex(std::numeric_limits<::ad_rss::physics::TimeIndex>::lowest());
+  valueTimeIndex = ::ad_rss::physics::TimeIndex(1); // set to valid value within struct
   value.timeIndex = valueTimeIndex;
   ::ad_rss::physics::AccelerationRange valueLateralLeftRange;
   ::ad_rss::physics::Acceleration valueLateralLeftRangeMinimum(-1e2);
@@ -229,6 +234,7 @@ TEST(AccelerationRestrictionValidInputRangeTests, testValidInputRangeLateralRigh
 {
   ::ad_rss::world::AccelerationRestriction value;
   ::ad_rss::physics::TimeIndex valueTimeIndex(std::numeric_limits<::ad_rss::physics::TimeIndex>::lowest());
+  valueTimeIndex = ::ad_rss::physics::TimeIndex(1); // set to valid value within struct
   value.timeIndex = valueTimeIndex;
   ::ad_rss::physics::AccelerationRange valueLateralLeftRange;
   ::ad_rss::physics::Acceleration valueLateralLeftRangeMinimum(-1e2);
@@ -267,6 +273,7 @@ TEST(AccelerationRestrictionValidInputRangeTests, testValidInputRangeLateralRigh
 {
   ::ad_rss::world::AccelerationRestriction value;
   ::ad_rss::physics::TimeIndex valueTimeIndex(std::numeric_limits<::ad_rss::physics::TimeIndex>::lowest());
+  valueTimeIndex = ::ad_rss::physics::TimeIndex(1); // set to valid value within struct
   value.timeIndex = valueTimeIndex;
   ::ad_rss::physics::AccelerationRange valueLateralLeftRange;
   ::ad_rss::physics::Acceleration valueLateralLeftRangeMinimum(-1e2);

--- a/tests/generated/world/RoadAreaValidInputRangeTests.cpp
+++ b/tests/generated/world/RoadAreaValidInputRangeTests.cpp
@@ -51,6 +51,31 @@ TEST(RoadAreaValidInputRangeTests, testValidInputRangeValidInputRangeMax)
 {
   ::ad_rss::world::RoadArea value;
   ::ad_rss::world::RoadSegment element;
+  ::ad_rss::world::LaneSegment elementElement;
+  ::ad_rss::world::LaneSegmentId elementElementId(std::numeric_limits<::ad_rss::world::LaneSegmentId>::lowest());
+  elementElement.id = elementElementId;
+  ::ad_rss::world::LaneSegmentType elementElementType(::ad_rss::world::LaneSegmentType::Normal);
+  elementElement.type = elementElementType;
+  ::ad_rss::world::LaneDrivingDirection elementElementDrivingDirection(
+    ::ad_rss::world::LaneDrivingDirection::Bidirectional);
+  elementElement.drivingDirection = elementElementDrivingDirection;
+  ::ad_rss::physics::MetricRange elementElementLength;
+  ::ad_rss::physics::Distance elementElementLengthMinimum(0.);
+  elementElementLength.minimum = elementElementLengthMinimum;
+  ::ad_rss::physics::Distance elementElementLengthMaximum(0.);
+  elementElementLength.maximum = elementElementLengthMaximum;
+  elementElementLength.maximum = elementElementLength.minimum;
+  elementElementLength.minimum = elementElementLength.maximum;
+  elementElement.length = elementElementLength;
+  ::ad_rss::physics::MetricRange elementElementWidth;
+  ::ad_rss::physics::Distance elementElementWidthMinimum(0.);
+  elementElementWidth.minimum = elementElementWidthMinimum;
+  ::ad_rss::physics::Distance elementElementWidthMaximum(0.);
+  elementElementWidth.maximum = elementElementWidthMaximum;
+  elementElementWidth.maximum = elementElementWidth.minimum;
+  elementElementWidth.minimum = elementElementWidth.maximum;
+  elementElement.width = elementElementWidth;
+  element.resize(1, elementElement);
   value.resize(1000, element);
   ASSERT_TRUE(withinValidInputRange(value));
 }
@@ -59,6 +84,31 @@ TEST(RoadAreaValidInputRangeTests, testValidInputRangeHigherThanInputRangeMax)
 {
   ::ad_rss::world::RoadArea value;
   ::ad_rss::world::RoadSegment element;
+  ::ad_rss::world::LaneSegment elementElement;
+  ::ad_rss::world::LaneSegmentId elementElementId(std::numeric_limits<::ad_rss::world::LaneSegmentId>::lowest());
+  elementElement.id = elementElementId;
+  ::ad_rss::world::LaneSegmentType elementElementType(::ad_rss::world::LaneSegmentType::Normal);
+  elementElement.type = elementElementType;
+  ::ad_rss::world::LaneDrivingDirection elementElementDrivingDirection(
+    ::ad_rss::world::LaneDrivingDirection::Bidirectional);
+  elementElement.drivingDirection = elementElementDrivingDirection;
+  ::ad_rss::physics::MetricRange elementElementLength;
+  ::ad_rss::physics::Distance elementElementLengthMinimum(0.);
+  elementElementLength.minimum = elementElementLengthMinimum;
+  ::ad_rss::physics::Distance elementElementLengthMaximum(0.);
+  elementElementLength.maximum = elementElementLengthMaximum;
+  elementElementLength.maximum = elementElementLength.minimum;
+  elementElementLength.minimum = elementElementLength.maximum;
+  elementElement.length = elementElementLength;
+  ::ad_rss::physics::MetricRange elementElementWidth;
+  ::ad_rss::physics::Distance elementElementWidthMinimum(0.);
+  elementElementWidth.minimum = elementElementWidthMinimum;
+  ::ad_rss::physics::Distance elementElementWidthMaximum(0.);
+  elementElementWidth.maximum = elementElementWidthMaximum;
+  elementElementWidth.maximum = elementElementWidth.minimum;
+  elementElementWidth.minimum = elementElementWidth.maximum;
+  elementElement.width = elementElementWidth;
+  element.resize(1, elementElement);
   value.resize(1001, element);
   ASSERT_FALSE(withinValidInputRange(value));
 }

--- a/tests/generated/world/RoadSegmentValidInputRangeTests.cpp
+++ b/tests/generated/world/RoadSegmentValidInputRangeTests.cpp
@@ -41,9 +41,39 @@
 
 #include "ad_rss/world/RoadSegmentValidInputRange.hpp"
 
+TEST(RoadSegmentValidInputRangeTests, testValidInputRangeLowerThanInputRangeMin)
+{
+  ::ad_rss::world::RoadSegment value;
+  ASSERT_FALSE(withinValidInputRange(value));
+}
+
 TEST(RoadSegmentValidInputRangeTests, testValidInputRangeValidInputRangeMin)
 {
   ::ad_rss::world::RoadSegment value;
+  ::ad_rss::world::LaneSegment element;
+  ::ad_rss::world::LaneSegmentId elementId(std::numeric_limits<::ad_rss::world::LaneSegmentId>::lowest());
+  element.id = elementId;
+  ::ad_rss::world::LaneSegmentType elementType(::ad_rss::world::LaneSegmentType::Normal);
+  element.type = elementType;
+  ::ad_rss::world::LaneDrivingDirection elementDrivingDirection(::ad_rss::world::LaneDrivingDirection::Bidirectional);
+  element.drivingDirection = elementDrivingDirection;
+  ::ad_rss::physics::MetricRange elementLength;
+  ::ad_rss::physics::Distance elementLengthMinimum(0.);
+  elementLength.minimum = elementLengthMinimum;
+  ::ad_rss::physics::Distance elementLengthMaximum(0.);
+  elementLength.maximum = elementLengthMaximum;
+  elementLength.maximum = elementLength.minimum;
+  elementLength.minimum = elementLength.maximum;
+  element.length = elementLength;
+  ::ad_rss::physics::MetricRange elementWidth;
+  ::ad_rss::physics::Distance elementWidthMinimum(0.);
+  elementWidth.minimum = elementWidthMinimum;
+  ::ad_rss::physics::Distance elementWidthMaximum(0.);
+  elementWidth.maximum = elementWidthMaximum;
+  elementWidth.maximum = elementWidth.minimum;
+  elementWidth.minimum = elementWidth.maximum;
+  element.width = elementWidth;
+  value.resize(1, element);
   ASSERT_TRUE(withinValidInputRange(value));
 }
 
@@ -113,6 +143,6 @@ TEST(RoadSegmentValidInputRangeTests, testValidInputRangeElementTypeInvalid)
   ::ad_rss::world::LaneSegment element;
   ::ad_rss::world::LaneSegmentType elementType(static_cast<::ad_rss::world::LaneSegmentType>(-1));
   element.type = elementType;
-  value.resize(999, element);
+  value.resize(1, element);
   ASSERT_FALSE(withinValidInputRange(value));
 }

--- a/tests/generated/world/SceneTests.cpp
+++ b/tests/generated/world/SceneTests.cpp
@@ -184,7 +184,7 @@ TEST_F(SceneTests, comparisonOperatorEgoVehicleRoadDiffers)
   egoVehicleRoadElementElementWidth.maximum = egoVehicleRoadElementElementWidth.minimum;
   egoVehicleRoadElementElementWidth.minimum = egoVehicleRoadElementElementWidth.maximum;
   egoVehicleRoadElementElement.width = egoVehicleRoadElementElementWidth;
-  egoVehicleRoadElement.resize(0 + 1, egoVehicleRoadElementElement);
+  egoVehicleRoadElement.resize(1 + 1, egoVehicleRoadElementElement);
   egoVehicleRoad.resize(0 + 1, egoVehicleRoadElement);
   valueA.egoVehicleRoad = egoVehicleRoad;
   ::ad_rss::world::Scene valueB = mValue;
@@ -223,7 +223,7 @@ TEST_F(SceneTests, comparisonOperatorIntersectingRoadDiffers)
   intersectingRoadElementElementWidth.maximum = intersectingRoadElementElementWidth.minimum;
   intersectingRoadElementElementWidth.minimum = intersectingRoadElementElementWidth.maximum;
   intersectingRoadElementElement.width = intersectingRoadElementElementWidth;
-  intersectingRoadElement.resize(0 + 1, intersectingRoadElementElement);
+  intersectingRoadElement.resize(1 + 1, intersectingRoadElementElement);
   intersectingRoad.resize(0 + 1, intersectingRoadElement);
   valueA.intersectingRoad = intersectingRoad;
   ::ad_rss::world::Scene valueB = mValue;

--- a/tests/generated/world/SceneValidInputRangeTests.cpp
+++ b/tests/generated/world/SceneValidInputRangeTests.cpp
@@ -298,6 +298,42 @@ TEST(SceneValidInputRangeTests, testValidInputRangeEgoVehicleRoadTooSmall)
   // override member with invalid value
   ::ad_rss::world::RoadArea invalidInitializedMember;
   ::ad_rss::world::RoadSegment invalidInitializedMemberRoadAreaElement;
+  ::ad_rss::world::LaneSegment invalidInitializedMemberRoadAreaElementElement;
+  ::ad_rss::world::LaneSegmentId invalidInitializedMemberRoadAreaElementElementId(
+    std::numeric_limits<::ad_rss::world::LaneSegmentId>::lowest());
+  invalidInitializedMemberRoadAreaElementElement.id = invalidInitializedMemberRoadAreaElementElementId;
+  ::ad_rss::world::LaneSegmentType invalidInitializedMemberRoadAreaElementElementType(
+    ::ad_rss::world::LaneSegmentType::Normal);
+  invalidInitializedMemberRoadAreaElementElement.type = invalidInitializedMemberRoadAreaElementElementType;
+  ::ad_rss::world::LaneDrivingDirection invalidInitializedMemberRoadAreaElementElementDrivingDirection(
+    ::ad_rss::world::LaneDrivingDirection::Bidirectional);
+  invalidInitializedMemberRoadAreaElementElement.drivingDirection
+    = invalidInitializedMemberRoadAreaElementElementDrivingDirection;
+  ::ad_rss::physics::MetricRange invalidInitializedMemberRoadAreaElementElementLength;
+  ::ad_rss::physics::Distance invalidInitializedMemberRoadAreaElementElementLengthMinimum(0.);
+  invalidInitializedMemberRoadAreaElementElementLength.minimum
+    = invalidInitializedMemberRoadAreaElementElementLengthMinimum;
+  ::ad_rss::physics::Distance invalidInitializedMemberRoadAreaElementElementLengthMaximum(0.);
+  invalidInitializedMemberRoadAreaElementElementLength.maximum
+    = invalidInitializedMemberRoadAreaElementElementLengthMaximum;
+  invalidInitializedMemberRoadAreaElementElementLength.maximum
+    = invalidInitializedMemberRoadAreaElementElementLength.minimum;
+  invalidInitializedMemberRoadAreaElementElementLength.minimum
+    = invalidInitializedMemberRoadAreaElementElementLength.maximum;
+  invalidInitializedMemberRoadAreaElementElement.length = invalidInitializedMemberRoadAreaElementElementLength;
+  ::ad_rss::physics::MetricRange invalidInitializedMemberRoadAreaElementElementWidth;
+  ::ad_rss::physics::Distance invalidInitializedMemberRoadAreaElementElementWidthMinimum(0.);
+  invalidInitializedMemberRoadAreaElementElementWidth.minimum
+    = invalidInitializedMemberRoadAreaElementElementWidthMinimum;
+  ::ad_rss::physics::Distance invalidInitializedMemberRoadAreaElementElementWidthMaximum(0.);
+  invalidInitializedMemberRoadAreaElementElementWidth.maximum
+    = invalidInitializedMemberRoadAreaElementElementWidthMaximum;
+  invalidInitializedMemberRoadAreaElementElementWidth.maximum
+    = invalidInitializedMemberRoadAreaElementElementWidth.minimum;
+  invalidInitializedMemberRoadAreaElementElementWidth.minimum
+    = invalidInitializedMemberRoadAreaElementElementWidth.maximum;
+  invalidInitializedMemberRoadAreaElementElement.width = invalidInitializedMemberRoadAreaElementElementWidth;
+  invalidInitializedMemberRoadAreaElement.resize(1, invalidInitializedMemberRoadAreaElementElement);
   invalidInitializedMember.resize(1001, invalidInitializedMemberRoadAreaElement);
   value.egoVehicleRoad = invalidInitializedMember;
   ASSERT_FALSE(withinValidInputRange(value));
@@ -401,7 +437,7 @@ TEST(SceneValidInputRangeTests, testValidInputRangeEgoVehicleRoadTooBig)
   invalidInitializedMemberRoadAreaElementElementWidth.minimum
     = invalidInitializedMemberRoadAreaElementElementWidth.maximum;
   invalidInitializedMemberRoadAreaElementElement.width = invalidInitializedMemberRoadAreaElementElementWidth;
-  invalidInitializedMemberRoadAreaElement.resize(0 + 1, invalidInitializedMemberRoadAreaElementElement);
+  invalidInitializedMemberRoadAreaElement.resize(1 + 1, invalidInitializedMemberRoadAreaElementElement);
   invalidInitializedMember.resize(1001, invalidInitializedMemberRoadAreaElement);
   value.egoVehicleRoad = invalidInitializedMember;
   ASSERT_FALSE(withinValidInputRange(value));
@@ -470,6 +506,42 @@ TEST(SceneValidInputRangeTests, testValidInputRangeIntersectingRoadTooSmall)
   // override member with invalid value
   ::ad_rss::world::RoadArea invalidInitializedMember;
   ::ad_rss::world::RoadSegment invalidInitializedMemberRoadAreaElement;
+  ::ad_rss::world::LaneSegment invalidInitializedMemberRoadAreaElementElement;
+  ::ad_rss::world::LaneSegmentId invalidInitializedMemberRoadAreaElementElementId(
+    std::numeric_limits<::ad_rss::world::LaneSegmentId>::lowest());
+  invalidInitializedMemberRoadAreaElementElement.id = invalidInitializedMemberRoadAreaElementElementId;
+  ::ad_rss::world::LaneSegmentType invalidInitializedMemberRoadAreaElementElementType(
+    ::ad_rss::world::LaneSegmentType::Normal);
+  invalidInitializedMemberRoadAreaElementElement.type = invalidInitializedMemberRoadAreaElementElementType;
+  ::ad_rss::world::LaneDrivingDirection invalidInitializedMemberRoadAreaElementElementDrivingDirection(
+    ::ad_rss::world::LaneDrivingDirection::Bidirectional);
+  invalidInitializedMemberRoadAreaElementElement.drivingDirection
+    = invalidInitializedMemberRoadAreaElementElementDrivingDirection;
+  ::ad_rss::physics::MetricRange invalidInitializedMemberRoadAreaElementElementLength;
+  ::ad_rss::physics::Distance invalidInitializedMemberRoadAreaElementElementLengthMinimum(0.);
+  invalidInitializedMemberRoadAreaElementElementLength.minimum
+    = invalidInitializedMemberRoadAreaElementElementLengthMinimum;
+  ::ad_rss::physics::Distance invalidInitializedMemberRoadAreaElementElementLengthMaximum(0.);
+  invalidInitializedMemberRoadAreaElementElementLength.maximum
+    = invalidInitializedMemberRoadAreaElementElementLengthMaximum;
+  invalidInitializedMemberRoadAreaElementElementLength.maximum
+    = invalidInitializedMemberRoadAreaElementElementLength.minimum;
+  invalidInitializedMemberRoadAreaElementElementLength.minimum
+    = invalidInitializedMemberRoadAreaElementElementLength.maximum;
+  invalidInitializedMemberRoadAreaElementElement.length = invalidInitializedMemberRoadAreaElementElementLength;
+  ::ad_rss::physics::MetricRange invalidInitializedMemberRoadAreaElementElementWidth;
+  ::ad_rss::physics::Distance invalidInitializedMemberRoadAreaElementElementWidthMinimum(0.);
+  invalidInitializedMemberRoadAreaElementElementWidth.minimum
+    = invalidInitializedMemberRoadAreaElementElementWidthMinimum;
+  ::ad_rss::physics::Distance invalidInitializedMemberRoadAreaElementElementWidthMaximum(0.);
+  invalidInitializedMemberRoadAreaElementElementWidth.maximum
+    = invalidInitializedMemberRoadAreaElementElementWidthMaximum;
+  invalidInitializedMemberRoadAreaElementElementWidth.maximum
+    = invalidInitializedMemberRoadAreaElementElementWidth.minimum;
+  invalidInitializedMemberRoadAreaElementElementWidth.minimum
+    = invalidInitializedMemberRoadAreaElementElementWidth.maximum;
+  invalidInitializedMemberRoadAreaElementElement.width = invalidInitializedMemberRoadAreaElementElementWidth;
+  invalidInitializedMemberRoadAreaElement.resize(1, invalidInitializedMemberRoadAreaElementElement);
   invalidInitializedMember.resize(1001, invalidInitializedMemberRoadAreaElement);
   value.intersectingRoad = invalidInitializedMember;
   ASSERT_FALSE(withinValidInputRange(value));
@@ -573,7 +645,7 @@ TEST(SceneValidInputRangeTests, testValidInputRangeIntersectingRoadTooBig)
   invalidInitializedMemberRoadAreaElementElementWidth.minimum
     = invalidInitializedMemberRoadAreaElementElementWidth.maximum;
   invalidInitializedMemberRoadAreaElementElement.width = invalidInitializedMemberRoadAreaElementElementWidth;
-  invalidInitializedMemberRoadAreaElement.resize(0 + 1, invalidInitializedMemberRoadAreaElementElement);
+  invalidInitializedMemberRoadAreaElement.resize(1 + 1, invalidInitializedMemberRoadAreaElementElement);
   invalidInitializedMember.resize(1001, invalidInitializedMemberRoadAreaElement);
   value.intersectingRoad = invalidInitializedMember;
   ASSERT_FALSE(withinValidInputRange(value));

--- a/tests/generated/world/WorldModelTests.cpp
+++ b/tests/generated/world/WorldModelTests.cpp
@@ -47,6 +47,7 @@ protected:
     // valid initialization
     ::ad_rss::world::WorldModel value;
     ::ad_rss::physics::TimeIndex valueTimeIndex(std::numeric_limits<::ad_rss::physics::TimeIndex>::lowest());
+    valueTimeIndex = ::ad_rss::physics::TimeIndex(1); // set to valid value within struct
     value.timeIndex = valueTimeIndex;
     ::ad_rss::world::Object valueEgoVehicle;
     ::ad_rss::world::ObjectId valueEgoVehicleObjectId(std::numeric_limits<::ad_rss::world::ObjectId>::lowest());
@@ -262,7 +263,7 @@ TEST_F(WorldModelTests, comparisonOperatorScenesDiffers)
   scenesElementEgoVehicleRoadElementElementWidth.maximum = scenesElementEgoVehicleRoadElementElementWidth.minimum;
   scenesElementEgoVehicleRoadElementElementWidth.minimum = scenesElementEgoVehicleRoadElementElementWidth.maximum;
   scenesElementEgoVehicleRoadElementElement.width = scenesElementEgoVehicleRoadElementElementWidth;
-  scenesElementEgoVehicleRoadElement.resize(0 + 1, scenesElementEgoVehicleRoadElementElement);
+  scenesElementEgoVehicleRoadElement.resize(1 + 1, scenesElementEgoVehicleRoadElementElement);
   scenesElementEgoVehicleRoad.resize(0 + 1, scenesElementEgoVehicleRoadElement);
   scenesElement.egoVehicleRoad = scenesElementEgoVehicleRoad;
   ::ad_rss::world::RoadArea scenesElementIntersectingRoad;
@@ -294,7 +295,7 @@ TEST_F(WorldModelTests, comparisonOperatorScenesDiffers)
   scenesElementIntersectingRoadElementElementWidth.maximum = scenesElementIntersectingRoadElementElementWidth.minimum;
   scenesElementIntersectingRoadElementElementWidth.minimum = scenesElementIntersectingRoadElementElementWidth.maximum;
   scenesElementIntersectingRoadElementElement.width = scenesElementIntersectingRoadElementElementWidth;
-  scenesElementIntersectingRoadElement.resize(0 + 1, scenesElementIntersectingRoadElementElement);
+  scenesElementIntersectingRoadElement.resize(1 + 1, scenesElementIntersectingRoadElementElement);
   scenesElementIntersectingRoad.resize(0 + 1, scenesElementIntersectingRoadElement);
   scenesElement.intersectingRoad = scenesElementIntersectingRoad;
   ::ad_rss::world::Object scenesElementObject;

--- a/tests/generated/world/WorldModelValidInputRangeTests.cpp
+++ b/tests/generated/world/WorldModelValidInputRangeTests.cpp
@@ -45,6 +45,7 @@ TEST(WorldModelValidInputRangeTests, testValidInputRange)
 {
   ::ad_rss::world::WorldModel value;
   ::ad_rss::physics::TimeIndex valueTimeIndex(std::numeric_limits<::ad_rss::physics::TimeIndex>::lowest());
+  valueTimeIndex = ::ad_rss::physics::TimeIndex(1); // set to valid value within struct
   value.timeIndex = valueTimeIndex;
   ::ad_rss::world::Object valueEgoVehicle;
   ::ad_rss::world::ObjectId valueEgoVehicleObjectId(std::numeric_limits<::ad_rss::world::ObjectId>::lowest());
@@ -105,6 +106,7 @@ TEST(WorldModelValidInputRangeTests, testValidInputRangeEgoVehicleTooSmall)
 {
   ::ad_rss::world::WorldModel value;
   ::ad_rss::physics::TimeIndex valueTimeIndex(std::numeric_limits<::ad_rss::physics::TimeIndex>::lowest());
+  valueTimeIndex = ::ad_rss::physics::TimeIndex(1); // set to valid value within struct
   value.timeIndex = valueTimeIndex;
   ::ad_rss::world::Object valueEgoVehicle;
   ::ad_rss::world::ObjectId valueEgoVehicleObjectId(std::numeric_limits<::ad_rss::world::ObjectId>::lowest());
@@ -171,6 +173,7 @@ TEST(WorldModelValidInputRangeTests, testValidInputRangeEgoVehicleTooBig)
 {
   ::ad_rss::world::WorldModel value;
   ::ad_rss::physics::TimeIndex valueTimeIndex(std::numeric_limits<::ad_rss::physics::TimeIndex>::lowest());
+  valueTimeIndex = ::ad_rss::physics::TimeIndex(1); // set to valid value within struct
   value.timeIndex = valueTimeIndex;
   ::ad_rss::world::Object valueEgoVehicle;
   ::ad_rss::world::ObjectId valueEgoVehicleObjectId(std::numeric_limits<::ad_rss::world::ObjectId>::lowest());
@@ -237,6 +240,7 @@ TEST(WorldModelValidInputRangeTests, testValidInputRangeScenesTooSmall)
 {
   ::ad_rss::world::WorldModel value;
   ::ad_rss::physics::TimeIndex valueTimeIndex(std::numeric_limits<::ad_rss::physics::TimeIndex>::lowest());
+  valueTimeIndex = ::ad_rss::physics::TimeIndex(1); // set to valid value within struct
   value.timeIndex = valueTimeIndex;
   ::ad_rss::world::Object valueEgoVehicle;
   ::ad_rss::world::ObjectId valueEgoVehicleObjectId(std::numeric_limits<::ad_rss::world::ObjectId>::lowest());
@@ -385,6 +389,7 @@ TEST(WorldModelValidInputRangeTests, testValidInputRangeScenesTooBig)
 {
   ::ad_rss::world::WorldModel value;
   ::ad_rss::physics::TimeIndex valueTimeIndex(std::numeric_limits<::ad_rss::physics::TimeIndex>::lowest());
+  valueTimeIndex = ::ad_rss::physics::TimeIndex(1); // set to valid value within struct
   value.timeIndex = valueTimeIndex;
   ::ad_rss::world::Object valueEgoVehicle;
   ::ad_rss::world::ObjectId valueEgoVehicleObjectId(std::numeric_limits<::ad_rss::world::ObjectId>::lowest());
@@ -488,7 +493,7 @@ TEST(WorldModelValidInputRangeTests, testValidInputRangeScenesTooBig)
   invalidInitializedMemberSceneVectorElementEgoVehicleRoadElementElement.width
     = invalidInitializedMemberSceneVectorElementEgoVehicleRoadElementElementWidth;
   invalidInitializedMemberSceneVectorElementEgoVehicleRoadElement.resize(
-    0 + 1, invalidInitializedMemberSceneVectorElementEgoVehicleRoadElementElement);
+    1 + 1, invalidInitializedMemberSceneVectorElementEgoVehicleRoadElementElement);
   invalidInitializedMemberSceneVectorElementEgoVehicleRoad.resize(
     0 + 1, invalidInitializedMemberSceneVectorElementEgoVehicleRoadElement);
   invalidInitializedMemberSceneVectorElement.egoVehicleRoad = invalidInitializedMemberSceneVectorElementEgoVehicleRoad;
@@ -537,7 +542,7 @@ TEST(WorldModelValidInputRangeTests, testValidInputRangeScenesTooBig)
   invalidInitializedMemberSceneVectorElementIntersectingRoadElementElement.width
     = invalidInitializedMemberSceneVectorElementIntersectingRoadElementElementWidth;
   invalidInitializedMemberSceneVectorElementIntersectingRoadElement.resize(
-    0 + 1, invalidInitializedMemberSceneVectorElementIntersectingRoadElementElement);
+    1 + 1, invalidInitializedMemberSceneVectorElementIntersectingRoadElementElement);
   invalidInitializedMemberSceneVectorElementIntersectingRoad.resize(
     0 + 1, invalidInitializedMemberSceneVectorElementIntersectingRoadElement);
   invalidInitializedMemberSceneVectorElement.intersectingRoad

--- a/tests/situation/RssSituationCheckingInputRangeTests.cpp
+++ b/tests/situation/RssSituationCheckingInputRangeTests.cpp
@@ -50,12 +50,12 @@ protected:
     situation.relativePosition.lateralDistance = Distance(0.);
     situation.relativePosition.lateralPosition = situation::LateralRelativePosition::Overlap;
     situation.situationType = situation::SituationType::SameDirection;
+    situation.timeIndex = 1u;
   }
 
   virtual void performTestRun()
   {
-    EXPECT_FALSE(situationChecking.checkSituation(situation, responseState));
-    EXPECT_FALSE(situationChecking.checkSituationInputRangeChecked(situation, responseState));
+    EXPECT_FALSE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
   }
   RssSituationChecking situationChecking;
   situation::VehicleState leadingVehicle;
@@ -299,7 +299,7 @@ TEST_F(RssSituationCheckingInputRangeTests, longitudinal_correct_deceleration_br
   situation.egoVehicleState.dynamics.alphaLon.brakeMax = Acceleration(4.);
   situation.egoVehicleState.dynamics.alphaLon.brakeMin = Acceleration(4.);
 
-  ASSERT_TRUE(situationChecking.checkSituation(situation, responseState));
+  ASSERT_TRUE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
 }
 
 TEST_F(RssSituationCheckingInputRangeTests, longitudinal_correct_deceleration_brake_min_equals_brake_min_correct)
@@ -308,7 +308,7 @@ TEST_F(RssSituationCheckingInputRangeTests, longitudinal_correct_deceleration_br
   situation.egoVehicleState.dynamics.alphaLon.brakeMin = Acceleration(3.);
   situation.egoVehicleState.dynamics.alphaLon.brakeMinCorrect = Acceleration(3.);
 
-  ASSERT_TRUE(situationChecking.checkSituation(situation, responseState));
+  ASSERT_TRUE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
 }
 
 TEST_F(RssSituationCheckingInputRangeTests,
@@ -318,7 +318,7 @@ TEST_F(RssSituationCheckingInputRangeTests,
   situation.egoVehicleState.dynamics.alphaLon.brakeMin = Acceleration(3.);
   situation.egoVehicleState.dynamics.alphaLon.brakeMinCorrect = Acceleration(3.);
 
-  ASSERT_TRUE(situationChecking.checkSituation(situation, responseState));
+  ASSERT_TRUE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
 }
 
 TEST_F(RssSituationCheckingInputRangeTests, situationVectorTooBig)

--- a/tests/situation/RssSituationCheckingTestsIntersectionInputRangeTests.cpp
+++ b/tests/situation/RssSituationCheckingTestsIntersectionInputRangeTests.cpp
@@ -41,12 +41,12 @@ protected:
   virtual void SetUp()
   {
     situation.situationType = SituationType::IntersectionEgoHasPriority;
+    situation.timeIndex = 1u;
   }
 
   void performTestRun()
   {
-    EXPECT_FALSE(situationChecking.checkSituation(situation, responseState));
-    EXPECT_FALSE(situationChecking.checkSituationInputRangeChecked(situation, responseState));
+    EXPECT_FALSE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
   }
   core::RssSituationChecking situationChecking;
   VehicleState leadingVehicle;
@@ -70,7 +70,7 @@ TEST_F(RssSituationCheckingTestsIntersectionInputRangeTests, no_priority_vehicle
   situation.otherVehicleState = followingVehicle;
   situation.relativePosition = createRelativeLongitudinalPosition(LongitudinalRelativePosition::InFront, Distance(60.));
 
-  ASSERT_TRUE(situationChecking.checkSituation(situation, responseState));
+  ASSERT_TRUE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
 }
 
 TEST_F(RssSituationCheckingTestsIntersectionInputRangeTests, distanceToLeaveSmallerEgo)

--- a/tests/situation/RssSituationCheckingTestsIntersectionNoPriority.cpp
+++ b/tests/situation/RssSituationCheckingTestsIntersectionNoPriority.cpp
@@ -64,6 +64,7 @@ TEST_F(RssSituationCheckingTestsIntersectionNoPriority, ego_following_no_overlap
 
     situation.relativePosition = createRelativeLongitudinalPosition(LongitudinalRelativePosition::AtBack, Distance(1.));
     situation.situationType = situationType;
+    situation.timeIndex = 1u;
     if (situationType == SituationType::IntersectionObjectHasPriority)
     {
       situation.otherVehicleState.hasPriority = true;
@@ -73,14 +74,14 @@ TEST_F(RssSituationCheckingTestsIntersectionNoPriority, ego_following_no_overlap
       situation.otherVehicleState.hasPriority = false;
     }
 
-    EXPECT_TRUE(situationChecking.checkSituation(situation, responseState));
+    EXPECT_TRUE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
     EXPECT_EQ(responseState.longitudinalState, cTestSupport.cLongitudinalSafe);
 
     // next situation we have overlap
     situation.timeIndex++;
     situation.egoVehicleState.velocity.speedLon = Speed(10);
 
-    EXPECT_TRUE(situationChecking.checkSituation(situation, responseState));
+    EXPECT_TRUE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
     if (situationType == SituationType::IntersectionObjectHasPriority)
     {
       EXPECT_EQ(responseState.longitudinalState, cTestSupport.cLongitudinalBrakeMin);
@@ -118,6 +119,7 @@ TEST_F(RssSituationCheckingTestsIntersectionNoPriority, 50kmh_safe_distance_ego_
     situation.relativePosition
       = createRelativeLongitudinalPosition(LongitudinalRelativePosition::AtBack, Distance(10.));
     situation.situationType = situationType;
+    situation.timeIndex = 1u;
     if (situationType == SituationType::IntersectionObjectHasPriority)
     {
       situation.otherVehicleState.hasPriority = true;
@@ -127,7 +129,7 @@ TEST_F(RssSituationCheckingTestsIntersectionNoPriority, 50kmh_safe_distance_ego_
       situation.otherVehicleState.hasPriority = false;
     }
 
-    ASSERT_TRUE(situationChecking.checkSituation(situation, responseState));
+    ASSERT_TRUE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
     ASSERT_EQ(responseState.longitudinalState, cTestSupport.cLongitudinalSafe);
   }
 }
@@ -151,6 +153,7 @@ TEST_F(RssSituationCheckingTestsIntersectionNoPriority, 50kmh_safe_distance_ego_
     situation.relativePosition
       = createRelativeLongitudinalPosition(LongitudinalRelativePosition::InFront, Distance(60.));
     situation.situationType = situationType;
+    situation.timeIndex++;
     if (situationType == SituationType::IntersectionObjectHasPriority)
     {
       situation.otherVehicleState.hasPriority = true;
@@ -160,7 +163,7 @@ TEST_F(RssSituationCheckingTestsIntersectionNoPriority, 50kmh_safe_distance_ego_
       situation.otherVehicleState.hasPriority = false;
     }
 
-    ASSERT_TRUE(situationChecking.checkSituation(situation, responseState));
+    ASSERT_TRUE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
     ASSERT_TRUE(responseState.longitudinalState.isSafe);
     ASSERT_EQ(responseState.longitudinalState, cTestSupport.cLongitudinalSafe);
   }
@@ -187,6 +190,7 @@ TEST_F(RssSituationCheckingTestsIntersectionNoPriority, 50km_h_stop_before_inter
     situation.relativePosition
       = createRelativeLongitudinalPosition(LongitudinalRelativePosition::InFront, Distance(30.));
     situation.situationType = situationType;
+    situation.timeIndex = 1u;
     if (situationType == SituationType::IntersectionObjectHasPriority)
     {
       situation.otherVehicleState.hasPriority = true;
@@ -197,22 +201,20 @@ TEST_F(RssSituationCheckingTestsIntersectionNoPriority, 50km_h_stop_before_inter
     }
 
     // both vehicles can stop safely
-    situation.timeIndex = 0u;
-
-    ASSERT_TRUE(situationChecking.checkSituation(situation, responseState));
+    ASSERT_TRUE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
     ASSERT_TRUE(responseState.longitudinalState.isSafe);
     ASSERT_EQ(responseState.longitudinalState, cTestSupport.cLongitudinalSafe);
 
     // ego vehicle cannot stop safely anymore
     // but other vehicle still
-    situation.timeIndex = 1u;
+    situation.timeIndex++;
 
     situation.egoVehicleState.distanceToEnterIntersection = Distance(70);
     situation.egoVehicleState.distanceToLeaveIntersection = Distance(70);
     situation.otherVehicleState.distanceToEnterIntersection = Distance(100);
     situation.otherVehicleState.distanceToLeaveIntersection = Distance(100);
 
-    ASSERT_TRUE(situationChecking.checkSituation(situation, responseState));
+    ASSERT_TRUE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
     if (situation.otherVehicleState.hasPriority)
     {
       ASSERT_FALSE(responseState.longitudinalState.isSafe);
@@ -225,14 +227,14 @@ TEST_F(RssSituationCheckingTestsIntersectionNoPriority, 50km_h_stop_before_inter
     }
 
     // both cannot stop safely anymore
-    situation.timeIndex = 2u;
+    situation.timeIndex++;
 
     situation.egoVehicleState.distanceToEnterIntersection = Distance(70.);
     situation.egoVehicleState.distanceToLeaveIntersection = Distance(70.);
     situation.otherVehicleState.distanceToEnterIntersection = Distance(70.);
     situation.otherVehicleState.distanceToLeaveIntersection = Distance(70.);
 
-    ASSERT_TRUE(situationChecking.checkSituation(situation, responseState));
+    ASSERT_TRUE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
     ASSERT_FALSE(responseState.longitudinalState.isSafe);
     ASSERT_EQ(responseState.longitudinalState, cTestSupport.cLongitudinalBrakeMin);
   }

--- a/tests/situation/RssSituationCheckingTestsIntersectionPriority.cpp
+++ b/tests/situation/RssSituationCheckingTestsIntersectionPriority.cpp
@@ -41,6 +41,7 @@ protected:
   virtual void SetUp()
   {
     situation.situationType = SituationType::IntersectionEgoHasPriority;
+    situation.timeIndex = 1u;
   }
 
   virtual void TearDown()
@@ -72,7 +73,7 @@ TEST_F(RssSituationCheckingTestsIntersectionPriority, 50kmh_safe_distance_ego_le
   situation.egoVehicleState = leadingVehicle;
   situation.relativePosition = createRelativeLongitudinalPosition(LongitudinalRelativePosition::InFront, Distance(10.));
 
-  ASSERT_TRUE(situationChecking.checkSituation(situation, responseState));
+  ASSERT_TRUE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
   ASSERT_EQ(responseState.longitudinalState, cTestSupport.cLongitudinalSafe);
 }
 
@@ -92,7 +93,7 @@ TEST_F(RssSituationCheckingTestsIntersectionPriority, 50kmh_safe_distance_ego_fo
   situation.egoVehicleState.hasPriority = true;
   situation.relativePosition = createRelativeLongitudinalPosition(LongitudinalRelativePosition::AtBack, Distance(60.));
 
-  ASSERT_TRUE(situationChecking.checkSituation(situation, responseState));
+  ASSERT_TRUE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
   ASSERT_TRUE(responseState.longitudinalState.isSafe);
   ASSERT_EQ(responseState.longitudinalState, cTestSupport.cLongitudinalSafe);
 }
@@ -115,20 +116,18 @@ TEST_F(RssSituationCheckingTestsIntersectionPriority, 50km_h_stop_before_interse
   situation.egoVehicleState.hasPriority = true;
   situation.relativePosition = createRelativeLongitudinalPosition(LongitudinalRelativePosition::AtBack, Distance(30.));
 
-  situation.timeIndex = 0u;
-
-  ASSERT_TRUE(situationChecking.checkSituation(situation, responseState));
+  ASSERT_TRUE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
   ASSERT_TRUE(responseState.longitudinalState.isSafe);
   ASSERT_EQ(responseState.longitudinalState, cTestSupport.cLongitudinalSafe);
 
-  situation.timeIndex = 1u;
+  situation.timeIndex++;
 
   situation.otherVehicleState.distanceToEnterIntersection = Distance(70.);
   situation.otherVehicleState.distanceToLeaveIntersection = Distance(70.);
   situation.egoVehicleState.distanceToEnterIntersection = Distance(100.);
   situation.egoVehicleState.distanceToLeaveIntersection = Distance(100.);
 
-  ASSERT_TRUE(situationChecking.checkSituation(situation, responseState));
+  ASSERT_TRUE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
   ASSERT_FALSE(responseState.longitudinalState.isSafe);
   ASSERT_EQ(responseState.longitudinalState, cTestSupport.cLongitudinalNone);
 }

--- a/tests/situation/RssSituationCheckingTestsLateral.cpp
+++ b/tests/situation/RssSituationCheckingTestsLateral.cpp
@@ -41,6 +41,7 @@ protected:
   virtual void SetUp()
   {
     situation.situationType = SituationType::SameDirection;
+    situation.timeIndex = 1u;
   }
 
   virtual void TearDown()
@@ -62,7 +63,7 @@ TEST_F(RssSituationCheckingTestsLateral, safe_left)
   situation.otherVehicleState = rightVehicle;
   situation.relativePosition = createRelativeLateralPosition(LateralRelativePosition::AtLeft, Distance(95.));
 
-  ASSERT_TRUE(situationChecking.checkSituation(situation, responseState));
+  ASSERT_TRUE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
   ASSERT_EQ(responseState.lateralStateRight, cTestSupport.cLateralSafe);
   ASSERT_EQ(responseState.lateralStateLeft, cTestSupport.cLateralSafe);
 }
@@ -76,7 +77,7 @@ TEST_F(RssSituationCheckingTestsLateral, not_safe_overlap_left)
   situation.otherVehicleState = rightVehicle;
   situation.relativePosition = createRelativeLateralPosition(LateralRelativePosition::OverlapLeft);
 
-  ASSERT_TRUE(situationChecking.checkSituation(situation, responseState));
+  ASSERT_TRUE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
   ASSERT_EQ(responseState.lateralStateRight, cTestSupport.cLateralBrakeMin);
   ASSERT_EQ(responseState.lateralStateLeft, cTestSupport.cLateralSafe);
 }
@@ -90,7 +91,7 @@ TEST_F(RssSituationCheckingTestsLateral, not_safe_overlap)
   situation.otherVehicleState = rightVehicle;
   situation.relativePosition = createRelativeLateralPosition(LateralRelativePosition::Overlap);
 
-  ASSERT_TRUE(situationChecking.checkSituation(situation, responseState));
+  ASSERT_TRUE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
   ASSERT_EQ(responseState.lateralStateRight, cTestSupport.cLateralBrakeMin);
   ASSERT_EQ(responseState.lateralStateLeft, cTestSupport.cLateralBrakeMin);
 }
@@ -104,7 +105,7 @@ TEST_F(RssSituationCheckingTestsLateral, not_safe_overlap_right)
   situation.otherVehicleState = rightVehicle;
   situation.relativePosition = createRelativeLateralPosition(LateralRelativePosition::OverlapRight);
 
-  ASSERT_TRUE(situationChecking.checkSituation(situation, responseState));
+  ASSERT_TRUE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
   ASSERT_EQ(responseState.lateralStateRight, cTestSupport.cLateralSafe);
   ASSERT_EQ(responseState.lateralStateLeft, cTestSupport.cLateralBrakeMin);
 }
@@ -118,7 +119,7 @@ TEST_F(RssSituationCheckingTestsLateral, safe_right)
   situation.otherVehicleState = rightVehicle;
   situation.relativePosition = createRelativeLateralPosition(LateralRelativePosition::AtRight, Distance(95.));
 
-  ASSERT_TRUE(situationChecking.checkSituation(situation, responseState));
+  ASSERT_TRUE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
   ASSERT_EQ(responseState.lateralStateRight, cTestSupport.cLateralSafe);
   ASSERT_EQ(responseState.lateralStateLeft, cTestSupport.cLateralSafe);
 }
@@ -132,7 +133,7 @@ TEST_F(RssSituationCheckingTestsLateral, both_move_right)
   situation.otherVehicleState = rightVehicle;
   situation.relativePosition = createRelativeLateralPosition(LateralRelativePosition::AtLeft, Distance(0.02));
 
-  ASSERT_TRUE(situationChecking.checkSituation(situation, responseState));
+  ASSERT_TRUE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
   ASSERT_EQ(responseState.lateralStateRight, cTestSupport.cLateralBrakeMin);
   ASSERT_EQ(responseState.lateralStateLeft, cTestSupport.cLateralSafe);
 }
@@ -146,7 +147,7 @@ TEST_F(RssSituationCheckingTestsLateral, move_towards_each_other)
   situation.otherVehicleState = rightVehicle;
   situation.relativePosition = createRelativeLateralPosition(LateralRelativePosition::AtLeft, Distance(0.02));
 
-  ASSERT_TRUE(situationChecking.checkSituation(situation, responseState));
+  ASSERT_TRUE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
   ASSERT_EQ(responseState.lateralStateRight, cTestSupport.cLateralBrakeMin);
   ASSERT_EQ(responseState.lateralStateLeft, cTestSupport.cLateralSafe);
 }
@@ -162,43 +163,50 @@ TEST_F(RssSituationCheckingTestsLateral, check_input_range)
   for (uint32_t i = 10; i > 1; i--)
   {
     situation.relativePosition = createRelativeLateralPosition(LateralRelativePosition::AtLeft, Distance(i));
+    situation.timeIndex++;
 
-    ASSERT_TRUE(situationChecking.checkSituation(situation, responseState));
+    ASSERT_TRUE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
     ASSERT_EQ(responseState.lateralStateRight, cTestSupport.cLateralSafe);
     ASSERT_EQ(responseState.lateralStateLeft, cTestSupport.cLateralSafe);
   }
 
   // near enough: trigger brake
   situation.relativePosition = createRelativeLateralPosition(LateralRelativePosition::AtLeft, Distance(1));
+  situation.timeIndex++;
 
-  ASSERT_TRUE(situationChecking.checkSituation(situation, responseState));
+  ASSERT_TRUE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
   ASSERT_EQ(responseState.lateralStateRight, cTestSupport.cLateralBrakeMin);
   ASSERT_EQ(responseState.lateralStateLeft, cTestSupport.cLateralSafe);
 
   // ego vehicle overlaps on left side
   situation.relativePosition = createRelativeLateralPosition(LateralRelativePosition::OverlapLeft);
+  situation.timeIndex++;
 
-  ASSERT_TRUE(situationChecking.checkSituation(situation, responseState));
+  ASSERT_TRUE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
   ASSERT_EQ(responseState.lateralStateRight, cTestSupport.cLateralBrakeMin);
   ASSERT_EQ(responseState.lateralStateLeft, cTestSupport.cLateralSafe);
 
   // ego vehicle totally overlaps with other vehicle
   situation.relativePosition = createRelativeLateralPosition(LateralRelativePosition::Overlap);
+  situation.timeIndex++;
 
-  ASSERT_TRUE(situationChecking.checkSituation(situation, responseState));
+  ASSERT_TRUE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
   ASSERT_EQ(responseState.lateralStateRight, cTestSupport.cLateralBrakeMin);
   ASSERT_EQ(responseState.lateralStateLeft, cTestSupport.cLateralBrakeMin);
 
   // ego vehicle overlaps on right side
   situation.relativePosition = createRelativeLateralPosition(LateralRelativePosition::OverlapRight);
+  situation.timeIndex++;
 
-  ASSERT_TRUE(situationChecking.checkSituation(situation, responseState));
+  ASSERT_TRUE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
   ASSERT_EQ(responseState.lateralStateRight, cTestSupport.cLateralSafe);
   ASSERT_EQ(responseState.lateralStateLeft, cTestSupport.cLateralBrakeMin);
 
   // ego vehicle still too near, but on right side
   situation.relativePosition = createRelativeLateralPosition(LateralRelativePosition::AtRight, Distance(1));
-  ASSERT_TRUE(situationChecking.checkSituation(situation, responseState));
+  situation.timeIndex++;
+
+  ASSERT_TRUE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
   ASSERT_EQ(responseState.lateralStateRight, cTestSupport.cLateralSafe);
   ASSERT_EQ(responseState.lateralStateLeft, cTestSupport.cLateralBrakeMin);
 
@@ -206,7 +214,8 @@ TEST_F(RssSituationCheckingTestsLateral, check_input_range)
   for (uint32_t i = 2; i < 10; i++)
   {
     situation.relativePosition = createRelativeLateralPosition(LateralRelativePosition::AtRight, Distance(i));
-    ASSERT_TRUE(situationChecking.checkSituation(situation, responseState));
+    situation.timeIndex++;
+    ASSERT_TRUE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
     ASSERT_EQ(responseState.lateralStateRight, cTestSupport.cLateralSafe);
     ASSERT_EQ(responseState.lateralStateLeft, cTestSupport.cLateralSafe);
   }

--- a/tests/situation/RssSituationCheckingTestsLongitudinal.cpp
+++ b/tests/situation/RssSituationCheckingTestsLongitudinal.cpp
@@ -41,6 +41,7 @@ protected:
   virtual void SetUp()
   {
     situation.situationType = SituationType::SameDirection;
+    situation.timeIndex = 1u;
   }
 
   virtual void TearDown()
@@ -62,7 +63,7 @@ TEST_F(RssSituationCheckingTestsLongitudinal, same_direction_leading_ego_safe_di
   situation.otherVehicleState = followingVehicle;
   situation.relativePosition = createRelativeLongitudinalPosition(LongitudinalRelativePosition::InFront, Distance(95.));
 
-  ASSERT_TRUE(situationChecking.checkSituation(situation, responseState));
+  ASSERT_TRUE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
   ASSERT_EQ(responseState.longitudinalState, cTestSupport.cLongitudinalSafe);
 }
 
@@ -77,7 +78,7 @@ TEST_F(RssSituationCheckingTestsLongitudinal, same_direction_leading_other_50kmh
   situation.otherVehicleState = leadingVehicle;
   situation.relativePosition = createRelativeLongitudinalPosition(LongitudinalRelativePosition::AtBack, Distance(60.));
 
-  ASSERT_TRUE(situationChecking.checkSituation(situation, responseState));
+  ASSERT_TRUE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
   ASSERT_EQ(responseState.longitudinalState, cTestSupport.cLongitudinalSafe);
 }
 
@@ -92,7 +93,7 @@ TEST_F(RssSituationCheckingTestsLongitudinal, same_direction_leading_other_50kmh
   situation.otherVehicleState = leadingVehicle;
   situation.relativePosition = createRelativeLongitudinalPosition(LongitudinalRelativePosition::AtBack, Distance(39.));
 
-  ASSERT_TRUE(situationChecking.checkSituation(situation, responseState));
+  ASSERT_TRUE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
   ASSERT_EQ(responseState.longitudinalState, cTestSupport.cLongitudinalBrakeMin);
 }
 
@@ -107,12 +108,13 @@ TEST_F(RssSituationCheckingTestsLongitudinal, same_direction_leading_other_50kmh
   situation.otherVehicleState = leadingVehicle;
   situation.relativePosition = createRelativeLongitudinalPosition(LongitudinalRelativePosition::AtBack, Distance(71.8));
 
-  ASSERT_TRUE(situationChecking.checkSituation(situation, responseState));
+  ASSERT_TRUE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
   ASSERT_EQ(responseState.longitudinalState, cTestSupport.cLongitudinalSafe);
 
   situation.relativePosition = createRelativeLongitudinalPosition(LongitudinalRelativePosition::AtBack, Distance(71.6));
+  situation.timeIndex++;
 
-  ASSERT_TRUE(situationChecking.checkSituation(situation, responseState));
+  ASSERT_TRUE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
   ASSERT_EQ(responseState.longitudinalState, cTestSupport.cLongitudinalBrakeMin);
 }
 
@@ -127,12 +129,13 @@ TEST_F(RssSituationCheckingTestsLongitudinal, same_direction_leading_other_0kmh_
   situation.otherVehicleState = leadingVehicle;
   situation.relativePosition = createRelativeLongitudinalPosition(LongitudinalRelativePosition::AtBack, Distance(6.1));
 
-  ASSERT_TRUE(situationChecking.checkSituation(situation, responseState));
+  ASSERT_TRUE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
   ASSERT_EQ(responseState.longitudinalState, cTestSupport.cLongitudinalSafe);
 
   situation.relativePosition = createRelativeLongitudinalPosition(LongitudinalRelativePosition::AtBack, Distance(6.));
+  situation.timeIndex++;
 
-  ASSERT_TRUE(situationChecking.checkSituation(situation, responseState));
+  ASSERT_TRUE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
   ASSERT_EQ(responseState.longitudinalState, cTestSupport.cLongitudinalBrakeMin);
 }
 
@@ -145,7 +148,7 @@ TEST_F(RssSituationCheckingTestsLongitudinal, same_direction_both_negative_veloc
   situation.otherVehicleState = leadingVehicle;
   situation.relativePosition = createRelativeLongitudinalPosition(LongitudinalRelativePosition::AtBack, Distance(71.6));
 
-  ASSERT_FALSE(situationChecking.checkSituation(situation, responseState));
+  ASSERT_FALSE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
 }
 
 } // namespace situation

--- a/tests/situation/RssSituationCheckingTestsNotRelevant.cpp
+++ b/tests/situation/RssSituationCheckingTestsNotRelevant.cpp
@@ -41,6 +41,7 @@ protected:
   virtual void SetUp()
   {
     situation.situationType = SituationType::NotRelevant;
+    situation.timeIndex = 1u;
   }
 
   virtual void TearDown()
@@ -63,7 +64,7 @@ TEST_F(RssSituationCheckingTestsNotRelevant, notRelevantSituation)
   situation.otherVehicleState = oppositeVehicle;
   situation.relativePosition = createRelativeLongitudinalPosition(LongitudinalRelativePosition::AtBack, Distance(1.));
 
-  ASSERT_TRUE(situationChecking.checkSituation(situation, responseState));
+  ASSERT_TRUE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
   ASSERT_EQ(responseState.longitudinalState, cTestSupport.cLongitudinalSafe);
 }
 

--- a/tests/situation/RssSituationCheckingTestsOppositeDirection.cpp
+++ b/tests/situation/RssSituationCheckingTestsOppositeDirection.cpp
@@ -41,6 +41,7 @@ protected:
   virtual void SetUp()
   {
     situation.situationType = SituationType::OppositeDirection;
+    situation.timeIndex = 1u;
   }
 
   virtual void TearDown()
@@ -63,7 +64,7 @@ TEST_F(RssSituationCheckingTestsOppositeDirection, 50kmh_brake_min_correct)
   situation.otherVehicleState = oppositeVehicle;
   situation.relativePosition = createRelativeLongitudinalPosition(LongitudinalRelativePosition::AtBack, Distance(178.));
 
-  ASSERT_TRUE(situationChecking.checkSituation(situation, responseState));
+  ASSERT_TRUE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
   ASSERT_EQ(responseState.longitudinalState, cTestSupport.cLongitudinalBrakeMinCorrect);
 }
 
@@ -79,12 +80,13 @@ TEST_F(RssSituationCheckingTestsOppositeDirection, 50kmh_shorter_ego_reaction_ti
 
   situation.relativePosition = createRelativeLongitudinalPosition(LongitudinalRelativePosition::AtBack, Distance(178.));
 
-  ASSERT_TRUE(situationChecking.checkSituation(situation, responseState));
+  ASSERT_TRUE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
   ASSERT_EQ(responseState.longitudinalState, cTestSupport.cLongitudinalSafe);
 
   situation.relativePosition = createRelativeLongitudinalPosition(LongitudinalRelativePosition::AtBack, Distance(150.));
+  situation.timeIndex++;
 
-  ASSERT_TRUE(situationChecking.checkSituation(situation, responseState));
+  ASSERT_TRUE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
   ASSERT_EQ(responseState.longitudinalState, cTestSupport.cLongitudinalBrakeMinCorrect);
 }
 
@@ -98,7 +100,7 @@ TEST_F(RssSituationCheckingTestsOppositeDirection, 50kmh_safe)
   situation.otherVehicleState = oppositeVehicle;
   situation.relativePosition = createRelativeLongitudinalPosition(LongitudinalRelativePosition::AtBack, Distance(197.));
 
-  ASSERT_TRUE(situationChecking.checkSituation(situation, responseState));
+  ASSERT_TRUE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
   ASSERT_EQ(responseState.longitudinalState, cTestSupport.cLongitudinalSafe);
 }
 
@@ -112,7 +114,7 @@ TEST_F(RssSituationCheckingTestsOppositeDirection, 50kmh_BrakeMinCorrect)
   situation.otherVehicleState = oppositeVehicle;
   situation.relativePosition = createRelativeLongitudinalPosition(LongitudinalRelativePosition::AtBack, Distance(196.));
 
-  ASSERT_TRUE(situationChecking.checkSituation(situation, responseState));
+  ASSERT_TRUE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
   ASSERT_EQ(responseState.longitudinalState, cTestSupport.cLongitudinalBrakeMinCorrect);
 }
 
@@ -127,7 +129,7 @@ TEST_F(RssSituationCheckingTestsOppositeDirection, 50kmh_response_1s_safe)
   situation.otherVehicleState = oppositeVehicle;
   situation.relativePosition = createRelativeLongitudinalPosition(LongitudinalRelativePosition::AtBack, Distance(196.));
 
-  ASSERT_TRUE(situationChecking.checkSituation(situation, responseState));
+  ASSERT_TRUE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
   ASSERT_EQ(responseState.longitudinalState, cTestSupport.cLongitudinalSafe);
 }
 
@@ -142,7 +144,7 @@ TEST_F(RssSituationCheckingTestsOppositeDirection, 50kmh_brake_min_correct_ego_v
   situation.relativePosition
     = createRelativeLongitudinalPosition(LongitudinalRelativePosition::InFront, Distance(178.7));
 
-  ASSERT_TRUE(situationChecking.checkSituation(situation, responseState));
+  ASSERT_TRUE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
   ASSERT_EQ(responseState.longitudinalState, cTestSupport.cLongitudinalBrakeMinCorrect);
 }
 
@@ -157,7 +159,7 @@ TEST_F(RssSituationCheckingTestsOppositeDirection, 50kmh_vehicles_at_same_positi
   situation.relativePosition
     = createRelativeLongitudinalPosition(LongitudinalRelativePosition::OverlapFront, Distance(0.));
 
-  ASSERT_TRUE(situationChecking.checkSituation(situation, responseState));
+  ASSERT_TRUE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
   ASSERT_EQ(responseState.longitudinalState, cTestSupport.cLongitudinalBrakeMinCorrect);
 }
 
@@ -174,7 +176,7 @@ TEST_F(RssSituationCheckingTestsOppositeDirection, incorrect_vehicle_state_ego)
   situation.relativePosition
     = createRelativeLongitudinalPosition(LongitudinalRelativePosition::AtBack, Distance(178.7));
 
-  ASSERT_FALSE(situationChecking.checkSituation(situation, responseState));
+  ASSERT_FALSE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
 }
 
 TEST_F(RssSituationCheckingTestsOppositeDirection, incorrect_vehicle_state_other)
@@ -190,7 +192,7 @@ TEST_F(RssSituationCheckingTestsOppositeDirection, incorrect_vehicle_state_other
   situation.relativePosition
     = createRelativeLongitudinalPosition(LongitudinalRelativePosition::AtBack, Distance(178.7));
 
-  ASSERT_FALSE(situationChecking.checkSituation(situation, responseState));
+  ASSERT_FALSE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
 }
 
 TEST_F(RssSituationCheckingTestsOppositeDirection, 50kmh_brake_min_ego_opposite)
@@ -204,7 +206,7 @@ TEST_F(RssSituationCheckingTestsOppositeDirection, 50kmh_brake_min_ego_opposite)
   situation.relativePosition
     = createRelativeLongitudinalPosition(LongitudinalRelativePosition::InFront, Distance(178.7));
 
-  ASSERT_TRUE(situationChecking.checkSituation(situation, responseState));
+  ASSERT_TRUE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
   ASSERT_EQ(responseState.longitudinalState, cTestSupport.cLongitudinalBrakeMin);
 }
 

--- a/tests/test_support/TestSupport.hpp
+++ b/tests/test_support/TestSupport.hpp
@@ -55,6 +55,8 @@ using physics::Speed;
 
 const double cDoubleNear(0.01);
 
+#define ARRAYLEN(a) (sizeof(a) / sizeof(a[0]))
+
 class TestSupport
 {
 public:


### PR DESCRIPTION
Adapting input borders
- Treat timeindex==0 as invalid input
- Treat empty road segments as invalid input

Added checks to enforce increasing time indices.
Had to move RssSituationChecking::checkSituation() to private to prevent
from misuse.

<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly and runs
  - [ ] Code is formatted using clang-3.9 and the provided format file
  - [ ] Changelog is updated

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->

Fixes #  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):** ...
  * **Library version:** ...

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel/ad-rss-lib/22)
<!-- Reviewable:end -->
