### PR TITLE
Added tests and reduced vector input ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * Added support for Clang 5 and Clang 6
 * Added checks to enforce increasing time indices
 * Consider timeIndex=0 as error
+* Reduced maximum vector input sizes to more feasible numbers (20 lane segments, 50 road segments, 100 scenes)
 
 ## Release 1.1.0
 * Made generated files and tests more explicit by moving into respective folders

--- a/include/generated/ad_rss/situation/SituationVectorValidInputRange.hpp
+++ b/include/generated/ad_rss/situation/SituationVectorValidInputRange.hpp
@@ -52,7 +52,7 @@
  * \returns \c true if SituationVector is considered to be within the specified input range
  *
  * \note the specified input range is defined by
- *       0 <= \c input.size() <= 1000
+ *       0 <= \c input.size() <= 100
  *       and the ranges of all vector elements
  */
 inline bool withinValidInputRange(::ad_rss::situation::SituationVector const &input)
@@ -60,7 +60,7 @@ inline bool withinValidInputRange(::ad_rss::situation::SituationVector const &in
   try
   {
     // LCOV_EXCL_BR_START: not always possible to cover especially all exception branches
-    bool inValidInputRange = (input.size() <= std::size_t(1000));
+    bool inValidInputRange = (input.size() <= std::size_t(100));
 
     if (inValidInputRange)
     {

--- a/include/generated/ad_rss/world/RoadAreaValidInputRange.hpp
+++ b/include/generated/ad_rss/world/RoadAreaValidInputRange.hpp
@@ -52,7 +52,7 @@
  * \returns \c true if RoadArea is considered to be within the specified input range
  *
  * \note the specified input range is defined by
- *       0 <= \c input.size() <= 1000
+ *       0 <= \c input.size() <= 50
  *       and the ranges of all vector elements
  */
 inline bool withinValidInputRange(::ad_rss::world::RoadArea const &input)
@@ -60,7 +60,7 @@ inline bool withinValidInputRange(::ad_rss::world::RoadArea const &input)
   try
   {
     // LCOV_EXCL_BR_START: not always possible to cover especially all exception branches
-    bool inValidInputRange = (input.size() <= std::size_t(1000));
+    bool inValidInputRange = (input.size() <= std::size_t(50));
 
     if (inValidInputRange)
     {

--- a/include/generated/ad_rss/world/RoadSegmentValidInputRange.hpp
+++ b/include/generated/ad_rss/world/RoadSegmentValidInputRange.hpp
@@ -52,7 +52,7 @@
  * \returns \c true if RoadSegment is considered to be within the specified input range
  *
  * \note the specified input range is defined by
- *       1 <= \c input.size() <= 1000
+ *       1 <= \c input.size() <= 20
  *       and the ranges of all vector elements
  */
 inline bool withinValidInputRange(::ad_rss::world::RoadSegment const &input)
@@ -60,7 +60,7 @@ inline bool withinValidInputRange(::ad_rss::world::RoadSegment const &input)
   try
   {
     // LCOV_EXCL_BR_START: not always possible to cover especially all exception branches
-    bool inValidInputRange = ((std::size_t(1)) <= input.size()) && (input.size() <= std::size_t(1000));
+    bool inValidInputRange = ((std::size_t(1)) <= input.size()) && (input.size() <= std::size_t(20));
 
     if (inValidInputRange)
     {

--- a/src/core/RssSituationExtraction.cpp
+++ b/src/core/RssSituationExtraction.cpp
@@ -145,6 +145,11 @@ bool convertObjectsNonIntersection(world::Object const &egoVehicle,
                                    world::Scene const &currentScene,
                                    situation::Situation &situation)
 {
+  if (!currentScene.intersectingRoad.empty())
+  {
+    return false;
+  }
+
   bool result = true;
 
   world::ObjectDimensions egoVehicleDimension;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,29 +43,30 @@ set(RSS_TEST_SOURCES_WITH_PRIVATE_ACCESS
   situation/RssSituationCheckingTestsIntersectionInputRangeTests.cpp
   situation/RssSituationCheckingTestsIntersectionNoPriority.cpp
   situation/RssSituationCheckingTestsIntersectionPriority.cpp
-  situation/RssSituationCheckingTestsLongitudinal.cpp
   situation/RssSituationCheckingTestsLateral.cpp
-  situation/RssSituationCheckingTestsOppositeDirection.cpp
+  situation/RssSituationCheckingTestsLongitudinal.cpp
   situation/RssSituationCheckingTestsNotRelevant.cpp
+  situation/RssSituationCheckingTestsOppositeDirection.cpp
 )
 
 set(RSS_TEST_SOURCES
-  core/RssCheckObjectTests.cpp
-  core/RssCheckTimeIndexTests.cpp
-  core/RssCheckSceneTests.cpp
-  core/RssCheckSameDirectionTests.cpp
-  core/RssCheckOppositeDirectionTests.cpp
-  core/RssCheckLateralTests.cpp
   core/RssCheckIntersectionTests.cpp
+  core/RssCheckLateralTests.cpp
+  core/RssCheckNotRelevantTests.cpp
+  core/RssCheckObjectTests.cpp
+  core/RssCheckOppositeDirectionTests.cpp
+  core/RssCheckSameDirectionTests.cpp
+  core/RssCheckSceneTests.cpp
+  core/RssCheckTimeIndexTests.cpp
   core/RssResponseResolvingTests.cpp
   core/RssResponseTransformationTests.cpp
-  core/RSSStateCombineRssStateTests.cpp
-  core/RSSStateSafeTests.cpp
   core/RssSituationExtractionInputRangeTests.cpp
-  core/RssSituationExtractionOppositeDirectionTests.cpp
   core/RssSituationExtractionIntersectionTests.cpp
+  core/RssSituationExtractionOppositeDirectionTests.cpp
   core/RssSituationExtractionRelativePositionTests.cpp
   core/RssSituationExtractionSameDirectionTests.cpp
+  core/RSSStateCombineRssStateTests.cpp
+  core/RSSStateSafeTests.cpp
   physics/MathUnitTestsDistanceOffsetAfterResponseTime.cpp
   physics/MathUnitTestsInputRangeChecks.cpp
   physics/MathUnitTestsStoppingDistance.cpp

--- a/tests/core/RssCheckNotRelevantTests.cpp
+++ b/tests/core/RssCheckNotRelevantTests.cpp
@@ -36,19 +36,19 @@ namespace core {
 
 template <class TESTBASE> class RssCheckNotRelevantTestBase : public TESTBASE
 {
-  virtual situation::SituationType getSituationType() override
+  situation::SituationType getSituationType() override
   {
     return situation::SituationType::NotRelevant;
   }
 
-  virtual ::ad_rss::world::Object &getEgoObject() override
+  ::ad_rss::world::Object &getEgoObject() override
   {
-    return objectOnSegment1;
+    return TESTBASE::objectOnSegment1;
   }
 
-  virtual ::ad_rss::world::Object &getSceneObject() override
+  ::ad_rss::world::Object &getSceneObject(uint32_t) override
   {
-    return objectOnSegment7;
+    return TESTBASE::objectOnSegment7;
   }
 };
 
@@ -77,7 +77,8 @@ TEST_F(RssCheckNotRelevantTest, NotRelevant)
 using RssCheckNotRelevantOutOfMemoryTest = RssCheckNotRelevantTestBase<RssCheckOutOfMemoryTestBase>;
 TEST_P(RssCheckNotRelevantOutOfMemoryTest, outOfMemoryAnyTime)
 {
-  performOutOfMemoryTest();
+  // throw at 3 will succeed, but that's expected in this case as no actual calculations are performed.
+  performOutOfMemoryTest({3u});
 }
 INSTANTIATE_TEST_CASE_P(Range, RssCheckNotRelevantOutOfMemoryTest, ::testing::Range(uint64_t(0u), uint64_t(50u)));
 

--- a/tests/core/RssCheckSceneTests.cpp
+++ b/tests/core/RssCheckSceneTests.cpp
@@ -29,6 +29,7 @@
 //
 // ----------------- END LICENSE BLOCK -----------------------------------
 
+#include <chrono>
 #include "RssCheckTestBaseT.hpp"
 
 namespace ad_rss {
@@ -40,8 +41,8 @@ class RssCheckSceneTests : public RssCheckTestBaseT<testing::Test>
 
 TEST_F(RssCheckSceneTests, EmptyEgoRoadSegment)
 {
-  ::ad_rss::world::AccelerationRestriction accelerationRestriction;
-  ::ad_rss::core::RssCheck rssCheck;
+  world::AccelerationRestriction accelerationRestriction;
+  core::RssCheck rssCheck;
 
   worldModel.scenes[0].egoVehicleRoad[0].clear();
 
@@ -50,18 +51,59 @@ TEST_F(RssCheckSceneTests, EmptyEgoRoadSegment)
 
 TEST_F(RssCheckSceneTests, EmptyEgoRoad)
 {
-  ::ad_rss::world::AccelerationRestriction accelerationRestriction;
-  ::ad_rss::core::RssCheck rssCheck;
+  world::AccelerationRestriction accelerationRestriction;
+  core::RssCheck rssCheck;
 
   worldModel.scenes[0].egoVehicleRoad.clear();
 
   ASSERT_FALSE(rssCheck.calculateAccelerationRestriction(worldModel, accelerationRestriction));
 }
 
+TEST_F(RssCheckSceneTests, EgoRoadIncomplete)
+{
+  world::AccelerationRestriction accelerationRestriction;
+  core::RssCheck rssCheck;
+
+  worldModel.scenes[0].egoVehicleRoad[1].clear();
+
+  ASSERT_FALSE(rssCheck.calculateAccelerationRestriction(worldModel, accelerationRestriction));
+}
+
+TEST_F(RssCheckSceneTests, IntersectionRoadButNotExpected)
+{
+  world::AccelerationRestriction accelerationRestriction;
+  core::RssCheck rssCheck;
+
+  worldModel.scenes[0].intersectingRoad = worldModel.scenes[0].egoVehicleRoad;
+
+  ASSERT_FALSE(rssCheck.calculateAccelerationRestriction(worldModel, accelerationRestriction));
+}
+
+TEST_F(RssCheckSceneTests, NoIntersectionRoadButExpected)
+{
+  world::AccelerationRestriction accelerationRestriction;
+  core::RssCheck rssCheck;
+
+  worldModel.scenes[0].situationType = situation::SituationType::IntersectionEgoHasPriority;
+
+  ASSERT_FALSE(rssCheck.calculateAccelerationRestriction(worldModel, accelerationRestriction));
+}
+
+TEST_F(RssCheckSceneTests, IntersectionRoadButNotIntersecting)
+{
+  world::AccelerationRestriction accelerationRestriction;
+  core::RssCheck rssCheck;
+
+  worldModel.scenes[0].situationType = situation::SituationType::IntersectionEgoHasPriority;
+  worldModel.scenes[0].intersectingRoad = worldModel.scenes[0].egoVehicleRoad;
+
+  ASSERT_FALSE(rssCheck.calculateAccelerationRestriction(worldModel, accelerationRestriction));
+}
+
 TEST_F(RssCheckSceneTests, EmptyScene)
 {
-  ::ad_rss::world::AccelerationRestriction accelerationRestriction;
-  ::ad_rss::core::RssCheck rssCheck;
+  world::AccelerationRestriction accelerationRestriction;
+  core::RssCheck rssCheck;
 
   worldModel.scenes.clear();
 
@@ -69,10 +111,53 @@ TEST_F(RssCheckSceneTests, EmptyScene)
   testRestrictions(accelerationRestriction);
 }
 
+TEST_F(RssCheckSceneTests, MaximumSceneSize)
+{
+  auto const basicScene = worldModel.scenes[0];
+
+  world::RoadSegment maximumRoadSegment = basicScene.egoVehicleRoad[0];
+  maximumRoadSegment.resize(20u, basicScene.egoVehicleRoad[0][0]);
+
+  world::Scene maximumScene = basicScene;
+  maximumScene.egoVehicleRoad.resize(50u, maximumRoadSegment);
+  for (size_t roadSegmentCount = 0u; roadSegmentCount < maximumScene.egoVehicleRoad.size(); roadSegmentCount++)
+  {
+    auto &roadSegment = maximumScene.egoVehicleRoad[roadSegmentCount];
+    for (size_t laneSegmentCount = 0u; laneSegmentCount < roadSegment.size(); laneSegmentCount++)
+    {
+      roadSegment[laneSegmentCount].id = roadSegmentCount * 1000u + 100u + laneSegmentCount;
+    }
+  }
+  maximumScene.egoVehicleRoad[0][0].id = 1;
+  maximumScene.egoVehicleRoad[49][19].id = 7;
+
+  world::SceneVector maximumSceneVector;
+  maximumSceneVector.resize(100, maximumScene);
+  for (size_t sceneCount = 0u; sceneCount < maximumSceneVector.size(); sceneCount++)
+  {
+    maximumSceneVector[sceneCount].object.objectId = sceneCount + 10u;
+  }
+
+  worldModel.scenes = maximumSceneVector;
+  world::AccelerationRestriction accelerationRestriction;
+  core::RssCheck rssCheck;
+
+  auto const start = std::chrono::system_clock::now();
+
+  ASSERT_TRUE(rssCheck.calculateAccelerationRestriction(worldModel, accelerationRestriction));
+  testRestrictions(accelerationRestriction);
+
+  auto const end = std::chrono::system_clock::now();
+  auto const diff = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+
+  // in debug build we should be below 500 ms
+  EXPECT_LE(diff.count(), 500);
+}
+
 TEST_F(RssCheckSceneTests, WrongEgoRoadMetricRangeLength)
 {
-  ::ad_rss::world::AccelerationRestriction accelerationRestriction;
-  ::ad_rss::core::RssCheck rssCheck;
+  world::AccelerationRestriction accelerationRestriction;
+  core::RssCheck rssCheck;
 
   worldModel.scenes[0].egoVehicleRoad[0][0].length.minimum = Distance(10);
   worldModel.scenes[0].egoVehicleRoad[0][0].length.maximum = Distance(5);
@@ -81,8 +166,8 @@ TEST_F(RssCheckSceneTests, WrongEgoRoadMetricRangeLength)
 
 TEST_F(RssCheckSceneTests, WrongEgoRoadMetricRangeWidth)
 {
-  ::ad_rss::world::AccelerationRestriction accelerationRestriction;
-  ::ad_rss::core::RssCheck rssCheck;
+  world::AccelerationRestriction accelerationRestriction;
+  core::RssCheck rssCheck;
 
   worldModel.scenes[0].egoVehicleRoad[0][0].width.minimum = Distance(10);
   worldModel.scenes[0].egoVehicleRoad[0][0].width.maximum = Distance(5);

--- a/tests/core/RssCheckTestBaseT.hpp
+++ b/tests/core/RssCheckTestBaseT.hpp
@@ -92,8 +92,8 @@ protected:
       occupiedRegion.lonRange.minimum = ParametricValue(0.);
       occupiedRegion.lonRange.maximum = ParametricValue(0.1);
       occupiedRegion.segmentId = 4;
-      occupiedRegion.latRange.minimum = ParametricValue(0.8);
-      occupiedRegion.latRange.maximum = ParametricValue(0.9);
+      occupiedRegion.latRange.minimum = ParametricValue(0.45);
+      occupiedRegion.latRange.maximum = ParametricValue(0.55);
       objectOnSegment4.occupiedRegions.push_back(occupiedRegion);
     }
 
@@ -528,37 +528,39 @@ protected:
     return Distance(0.);
   }
 
-  bool isDistanceSafe()
+  bool isDistanceSafeLongitudinal()
   {
-    Distance dMin;
-    switch (getSituationType())
+    for (auto const &scene : worldModel.scenes)
     {
-      case situation::SituationType::SameDirection:
-        dMin = calculateLongitudinalMinSafeDistance(worldModel.egoVehicle, worldModel.scenes[0].object);
-        break;
-      case situation::SituationType::OppositeDirection:
-        dMin
-          = calculateLongitudinalMinSafeDistanceOppositeDirection(worldModel.egoVehicle, worldModel.scenes[0].object);
-        break;
-      default:
-        EXPECT_TRUE(false);
-        break;
-    }
+      Distance dMin;
+      switch (getSituationType())
+      {
+        case situation::SituationType::SameDirection:
+          dMin = calculateLongitudinalMinSafeDistance(worldModel.egoVehicle, scene.object);
+          break;
+        case situation::SituationType::OppositeDirection:
+          dMin = calculateLongitudinalMinSafeDistanceOppositeDirection(worldModel.egoVehicle, scene.object);
+          break;
+        default:
+          EXPECT_TRUE(false);
+          break;
+      }
 
-    Distance egoDistanceToSegmentEnd = getDistanceToSegmentEnd(worldModel.egoVehicle);
-    Distance objectDistanceFromSegmentBegin = getFrontObjectDistanceFromSegmentBegin();
-    Distance additionalLength{0u};
-    if ((worldModel.egoVehicle.occupiedRegions[0].segmentId < 3)
-        || (worldModel.egoVehicle.occupiedRegions[0].segmentId > 5))
-    {
-      // ego in front or in the back, then the middle segment is relevant
-      additionalLength = getMiddleRoadSegmentLength();
+      Distance egoDistanceToSegmentEnd = getDistanceToSegmentEnd(worldModel.egoVehicle);
+      Distance objectDistanceFromSegmentBegin = getFrontObjectDistanceFromSegmentBegin();
+      Distance additionalLength{0u};
+      if ((worldModel.egoVehicle.occupiedRegions[0].segmentId < 3)
+          || (worldModel.egoVehicle.occupiedRegions[0].segmentId > 5))
+      {
+        // ego in front or in the back, then the middle segment is relevant
+        additionalLength = getMiddleRoadSegmentLength();
+      }
+      if (dMin >= additionalLength + egoDistanceToSegmentEnd + objectDistanceFromSegmentBegin)
+      {
+        return false;
+      }
     }
-    if (dMin < additionalLength + egoDistanceToSegmentEnd + objectDistanceFromSegmentBegin)
-    {
-      return true;
-    }
-    return false;
+    return true;
   }
 
   virtual void performDifferentVelocitiesTest(state::LongitudinalResponse expectedLonResponse)
@@ -573,7 +575,7 @@ protected:
 
       ASSERT_TRUE(rssCheck.calculateAccelerationRestriction(worldModel, accelerationRestriction));
 
-      if (isDistanceSafe())
+      if (isDistanceSafeLongitudinal())
       {
         testRestrictions(accelerationRestriction);
       }
@@ -597,7 +599,7 @@ protected:
 
       ASSERT_TRUE(rssCheck.calculateAccelerationRestriction(worldModel, accelerationRestriction));
 
-      if (isDistanceSafe())
+      if (isDistanceSafeLongitudinal())
       {
         testRestrictions(accelerationRestriction);
       }

--- a/tests/core/RssCheckTestBaseT.hpp
+++ b/tests/core/RssCheckTestBaseT.hpp
@@ -33,6 +33,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <vector>
 
 #include "TestSupport.hpp"
 #include "ad_rss/core/RssCheck.hpp"
@@ -499,11 +500,6 @@ protected:
     testRestriction(accelerationRestriction.lateralRightRange, expectedLatResponseRight);
   }
 
-  virtual void performOutOfMemoryTest()
-  {
-    ASSERT_TRUE(false);
-  }
-
   Distance getDistanceToSegmentEnd(::ad_rss::world::Object const &object)
   {
     world::LaneSegment objectRoadSegment = getMergedRoadSegment(object.occupiedRegions[0].segmentId);
@@ -630,14 +626,16 @@ using RssCheckTestBase = RssCheckTestBaseT<testing::Test>;
 class RssCheckOutOfMemoryTestBase : public RssCheckTestBaseT<testing::TestWithParam<uint64_t>>
 {
 protected:
-  void performOutOfMemoryTest() override
+  void performOutOfMemoryTest(std::vector<uint64_t> additionalSucceessResults = {})
   {
     gNewThrowCounter = GetParam();
     ::ad_rss::world::AccelerationRestriction accelerationRestriction;
     ::ad_rss::core::RssCheck rssCheck;
 
     bool const checkResult = rssCheck.calculateAccelerationRestriction(worldModel, accelerationRestriction);
-    if ((GetParam() == 0) || (gNewThrowCounter > 0u))
+    if ((GetParam() == 0) || (gNewThrowCounter > 0u)
+        || (additionalSucceessResults.end()
+            != std::find(additionalSucceessResults.begin(), additionalSucceessResults.end(), GetParam())))
     {
       // for 0 there is no out of memory
       // as there are not more than a certain amount of allocations while running, from a certain border on

--- a/tests/core/RssResponseTransformationTests.cpp
+++ b/tests/core/RssResponseTransformationTests.cpp
@@ -71,6 +71,12 @@ TEST_F(RssResponseTransformationTests, invalidTimeStamp)
 
   ASSERT_FALSE(::ad_rss::core::RssResponseTransformation::transformProperResponse(
     worldModel, responseState, accelerationRestriction));
+
+  worldModel.timeIndex = 1u;
+  responseState.timeIndex = 2u;
+
+  ASSERT_FALSE(::ad_rss::core::RssResponseTransformation::transformProperResponse(
+    worldModel, responseState, accelerationRestriction));
 }
 
 TEST_F(RssResponseTransformationTests, invalidLongitudinalResponseState)

--- a/tests/generated/situation/SituationVectorValidInputRangeTests.cpp
+++ b/tests/generated/situation/SituationVectorValidInputRangeTests.cpp
@@ -182,7 +182,7 @@ TEST(SituationVectorValidInputRangeTests, testValidInputRangeValidInputRangeMax)
   ::ad_rss::physics::Distance elementRelativePositionLateralDistance(0.);
   elementRelativePosition.lateralDistance = elementRelativePositionLateralDistance;
   element.relativePosition = elementRelativePosition;
-  value.resize(1000, element);
+  value.resize(100, element);
   ASSERT_TRUE(withinValidInputRange(value));
 }
 
@@ -321,7 +321,7 @@ TEST(SituationVectorValidInputRangeTests, testValidInputRangeHigherThanInputRang
   ::ad_rss::physics::Distance elementRelativePositionLateralDistance(0.);
   elementRelativePosition.lateralDistance = elementRelativePositionLateralDistance;
   element.relativePosition = elementRelativePosition;
-  value.resize(1001, element);
+  value.resize(101, element);
   ASSERT_FALSE(withinValidInputRange(value));
 }
 
@@ -331,6 +331,6 @@ TEST(SituationVectorValidInputRangeTests, testValidInputRangeElementTypeInvalid)
   ::ad_rss::situation::Situation element;
   ::ad_rss::situation::SituationType elementSituationType(static_cast<::ad_rss::situation::SituationType>(-1));
   element.situationType = elementSituationType;
-  value.resize(999, element);
+  value.resize(99, element);
   ASSERT_FALSE(withinValidInputRange(value));
 }

--- a/tests/generated/world/RoadAreaValidInputRangeTests.cpp
+++ b/tests/generated/world/RoadAreaValidInputRangeTests.cpp
@@ -76,7 +76,7 @@ TEST(RoadAreaValidInputRangeTests, testValidInputRangeValidInputRangeMax)
   elementElementWidth.minimum = elementElementWidth.maximum;
   elementElement.width = elementElementWidth;
   element.resize(1, elementElement);
-  value.resize(1000, element);
+  value.resize(50, element);
   ASSERT_TRUE(withinValidInputRange(value));
 }
 
@@ -109,7 +109,7 @@ TEST(RoadAreaValidInputRangeTests, testValidInputRangeHigherThanInputRangeMax)
   elementElementWidth.minimum = elementElementWidth.maximum;
   elementElement.width = elementElementWidth;
   element.resize(1, elementElement);
-  value.resize(1001, element);
+  value.resize(51, element);
   ASSERT_FALSE(withinValidInputRange(value));
 }
 
@@ -142,7 +142,7 @@ TEST(RoadAreaValidInputRangeTests, testValidInputRangeElementTypeInvalid)
   elementRoadSegmentElementWidth.maximum = elementRoadSegmentElementWidth.minimum;
   elementRoadSegmentElementWidth.minimum = elementRoadSegmentElementWidth.maximum;
   elementRoadSegmentElement.width = elementRoadSegmentElementWidth;
-  element.resize(1001, elementRoadSegmentElement);
-  value.resize(999, element);
+  element.resize(21, elementRoadSegmentElement);
+  value.resize(49, element);
   ASSERT_FALSE(withinValidInputRange(value));
 }

--- a/tests/generated/world/RoadSegmentValidInputRangeTests.cpp
+++ b/tests/generated/world/RoadSegmentValidInputRangeTests.cpp
@@ -103,7 +103,7 @@ TEST(RoadSegmentValidInputRangeTests, testValidInputRangeValidInputRangeMax)
   elementWidth.maximum = elementWidth.minimum;
   elementWidth.minimum = elementWidth.maximum;
   element.width = elementWidth;
-  value.resize(1000, element);
+  value.resize(20, element);
   ASSERT_TRUE(withinValidInputRange(value));
 }
 
@@ -133,7 +133,7 @@ TEST(RoadSegmentValidInputRangeTests, testValidInputRangeHigherThanInputRangeMax
   elementWidth.maximum = elementWidth.minimum;
   elementWidth.minimum = elementWidth.maximum;
   element.width = elementWidth;
-  value.resize(1001, element);
+  value.resize(21, element);
   ASSERT_FALSE(withinValidInputRange(value));
 }
 

--- a/tests/generated/world/SceneValidInputRangeTests.cpp
+++ b/tests/generated/world/SceneValidInputRangeTests.cpp
@@ -334,7 +334,7 @@ TEST(SceneValidInputRangeTests, testValidInputRangeEgoVehicleRoadTooSmall)
     = invalidInitializedMemberRoadAreaElementElementWidth.maximum;
   invalidInitializedMemberRoadAreaElementElement.width = invalidInitializedMemberRoadAreaElementElementWidth;
   invalidInitializedMemberRoadAreaElement.resize(1, invalidInitializedMemberRoadAreaElementElement);
-  invalidInitializedMember.resize(1001, invalidInitializedMemberRoadAreaElement);
+  invalidInitializedMember.resize(51, invalidInitializedMemberRoadAreaElement);
   value.egoVehicleRoad = invalidInitializedMember;
   ASSERT_FALSE(withinValidInputRange(value));
 }
@@ -438,7 +438,7 @@ TEST(SceneValidInputRangeTests, testValidInputRangeEgoVehicleRoadTooBig)
     = invalidInitializedMemberRoadAreaElementElementWidth.maximum;
   invalidInitializedMemberRoadAreaElementElement.width = invalidInitializedMemberRoadAreaElementElementWidth;
   invalidInitializedMemberRoadAreaElement.resize(1 + 1, invalidInitializedMemberRoadAreaElementElement);
-  invalidInitializedMember.resize(1001, invalidInitializedMemberRoadAreaElement);
+  invalidInitializedMember.resize(51, invalidInitializedMemberRoadAreaElement);
   value.egoVehicleRoad = invalidInitializedMember;
   ASSERT_FALSE(withinValidInputRange(value));
 }
@@ -542,7 +542,7 @@ TEST(SceneValidInputRangeTests, testValidInputRangeIntersectingRoadTooSmall)
     = invalidInitializedMemberRoadAreaElementElementWidth.maximum;
   invalidInitializedMemberRoadAreaElementElement.width = invalidInitializedMemberRoadAreaElementElementWidth;
   invalidInitializedMemberRoadAreaElement.resize(1, invalidInitializedMemberRoadAreaElementElement);
-  invalidInitializedMember.resize(1001, invalidInitializedMemberRoadAreaElement);
+  invalidInitializedMember.resize(51, invalidInitializedMemberRoadAreaElement);
   value.intersectingRoad = invalidInitializedMember;
   ASSERT_FALSE(withinValidInputRange(value));
 }
@@ -646,7 +646,7 @@ TEST(SceneValidInputRangeTests, testValidInputRangeIntersectingRoadTooBig)
     = invalidInitializedMemberRoadAreaElementElementWidth.maximum;
   invalidInitializedMemberRoadAreaElementElement.width = invalidInitializedMemberRoadAreaElementElementWidth;
   invalidInitializedMemberRoadAreaElement.resize(1 + 1, invalidInitializedMemberRoadAreaElementElement);
-  invalidInitializedMember.resize(1001, invalidInitializedMemberRoadAreaElement);
+  invalidInitializedMember.resize(51, invalidInitializedMemberRoadAreaElement);
   value.intersectingRoad = invalidInitializedMember;
   ASSERT_FALSE(withinValidInputRange(value));
 }

--- a/tests/situation/RssSituationCheckingInputRangeTests.cpp
+++ b/tests/situation/RssSituationCheckingInputRangeTests.cpp
@@ -64,6 +64,11 @@ protected:
   state::ResponseState responseState;
 };
 
+TEST_F(RssSituationCheckingInputRangeTests, validateTestSetup)
+{
+  EXPECT_TRUE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
+}
+
 /**
  * Invalid longitudinal acceleration
  */
@@ -321,11 +326,36 @@ TEST_F(RssSituationCheckingInputRangeTests,
   ASSERT_TRUE(situationChecking.checkSituationInputRangeChecked(situation, true, responseState));
 }
 
-TEST_F(RssSituationCheckingInputRangeTests, situationVectorTooBig)
+TEST_F(RssSituationCheckingInputRangeTests, situationVectorSizeRange)
+{
+  for (size_t situationCount = 0u; situationCount < 110u; situationCount += 5u)
+  {
+    situation::SituationVector situationVector;
+    state::ResponseStateVector responseStateVector;
+    situationVector.resize(situationCount, situation);
+    for (size_t i = 0u; i < situationCount; ++i)
+    {
+      situation.situationId = i;
+      situation.timeIndex = situationCount;
+    }
+
+    if (situationCount <= 100u)
+    {
+      EXPECT_TRUE(situationChecking.checkSituations(situationVector, responseStateVector));
+    }
+    else
+    {
+      EXPECT_FALSE(situationChecking.checkSituations(situationVector, responseStateVector));
+    }
+  }
+}
+
+TEST_F(RssSituationCheckingInputRangeTests, situationVectorDifferentTimestamps)
 {
   situation::SituationVector situationVector;
   state::ResponseStateVector responseStateVector;
-  situationVector.resize(1001, situation);
+  situationVector.resize(2, situation);
+  situationVector[0].timeIndex++;
   ASSERT_FALSE(situationChecking.checkSituations(situationVector, responseStateVector));
 }
 


### PR DESCRIPTION
- RssCheckLateralEgoInTheMiddleTestBase.*
- Added corner cases
- Reduced some vector ranges:
max lane segments 20
max road segments 50
max scenes 100

<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [X] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [X] Extended the README / documentation, if necessary
  - [X] Code compiles correctly and runs
  - [X] Code is formatted using clang-3.9 and the provided format file
  - [X] Changelog is updated

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->

Fixes #  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):** ...
  * **Library version:** ...

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel/ad-rss-lib/27)
<!-- Reviewable:end -->
