### PR TITLE
Fix clang options

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -98,13 +98,22 @@ target_link_libraries(${EXEC_NAME} PRIVATE
 )
 
 # Disable warnings for gtest and gtest_main
-set_property(TARGET gtest gtest_main APPEND_STRING PROPERTY COMPILE_FLAGS " -w")
+if(TARGET gtest)
+  set_property(TARGET gtest APPEND_STRING PROPERTY COMPILE_FLAGS " -w")
+endif()
+# Disable warnings for gtest and gtest_main
+if(TARGET gtest_main)
+  set_property(TARGET gtest_main APPEND_STRING PROPERTY COMPILE_FLAGS " -w")
+endif()
+
+
+target_compile_options(${EXEC_NAME} PRIVATE ${COVERAGE_FLAG} ${TARGET_COMPILE_OPTIONS})
 
 # Clang is more restrictive with warnings than GCC
 # Some warnings are due to required tests, e.g. force move operator
 # Disable these warnings
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-  target_compile_options(${EXEC_NAME} PRIVATE ${COVERAGE_FLAG} ${TARGET_COMPILE_OPTIONS} -Wno-pessimizing-move -Wno-unused-comparison)
+  target_compile_options(${EXEC_NAME} PRIVATE -Wno-pessimizing-move -Wno-unused-comparison)
 endif()
 set_target_properties(${EXEC_NAME} PROPERTIES LINK_FLAGS "${COVERAGE_FLAG} ${HARDENING_LD_FLAGS}")
 


### PR DESCRIPTION
- set gtest target properties only if the target actually exist
- set standard compile options always

<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [x] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [x] Extended the README / documentation, if necessary
  - [x] Code compiles correctly and runs
  - [x] Code is formatted using clang-3.9 and the provided format file
  - [x] Changelog is updated

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->

Fixes #  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):** ...
  * **Library version:** ...

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
