### PR TITLE
Added static code analysis using clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,27 @@
+---
+Checks:          '*,-clang-analyzer-alpha.deadcode.UnreachableCode,-modernize-make-unique,-modernize-use-default,-modernize-pass-by-value,-misc-noexcept-move-constructor,-llvm-include-order'
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: false
+CheckOptions:
+  - key:             google-readability-braces-around-statements.ShortStatementLines
+    value:           '1'
+  - key:             google-readability-function-size.StatementThreshold
+    value:           '800'
+  - key:             google-readability-namespace-comments.ShortNamespaceLines
+    value:           '10'
+  - key:             google-readability-namespace-comments.SpacesBeforeComments
+    value:           '2'
+  - key:             modernize-loop-convert.MaxCopySize
+    value:           '16'
+  - key:             modernize-loop-convert.MinConfidence
+    value:           reasonable
+  - key:             modernize-loop-convert.NamingStyle
+    value:           CamelCase
+  - key:             modernize-pass-by-value.IncludeStyle
+    value:           llvm
+  - key:             modernize-replace-auto-ptr.IncludeStyle
+    value:           llvm
+  - key:             modernize-use-nullptr.NullMacros
+    value:           'NULL'
+...
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,6 +107,25 @@ matrix:
       after_failure:
         - tail --lines=2000 build.log
 
+    - env: TEST="Static Code Analysis"
+      addons:
+        apt:
+          packages:
+            - cmake
+            - build-essential
+            - libgtest-dev
+            - lcov
+            - clang-tidy
+            - clang-3.8
+      script:
+        - mkdir build
+        - cd build
+        - cmake .. -DBUILD_STATIC_ANALYSIS=ON
+        - make clang-tidy
+        - if [ -f clangtidy.yml ]; then echo "Static code analysis with clang-tidy failed. Please run 'make clang-tidy'"; exit 1; fi
+      after_failure:
+        - tail --lines=2000 build.log
+
     - env: TEST="Documentation Deployment"
       if: branch = master AND type != pull_request
       git:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Latest changes
+* Small updates to be compliant to clang-tidy-3.8 static code analysis
 
 ## Release 1.2.0
 * Added support for Clang 5 and Clang 6

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ set(BUILD_TESTING "ON" CACHE BOOL "Enable test compilation")
 set(BUILD_DOC "OFF" CACHE BOOL "Enable compilation of doxygen documentation")
 set(BUILD_HARDENING "OFF" CACHE BOOL "Enable build hardening flags")
 set(BUILD_COVERAGE "OFF" CACHE BOOL "Enable test coverage")
+set(BUILD_STATIC_ANALYSIS "OFF" CACHE BOOL "Enable static code analysis")
 
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
@@ -112,6 +113,21 @@ add_library(${PROJECT_NAME} SHARED
   src/world/RssSituationCoordinateSystemConversion.cpp
   src/world/RssObjectPositionExtractor.cpp
   ${GENERATED_SOURCES}
+)
+
+set(ALL_SOURCES
+  ${GENERATED_SOURCES}
+  src/core/RssCheck.cpp
+  src/core/RssResponseResolving.cpp
+  src/core/RssResponseTransformation.cpp
+  src/core/RssSituationChecking.cpp
+  src/core/RssSituationExtraction.cpp
+  src/physics/Math.cpp
+  src/situation/RSSFormulas.cpp
+  src/situation/RssIntersectionChecker.cpp
+  src/situation/RSSSituation.cpp
+  src/world/RssSituationCoordinateSystemConversion.cpp
+  src/world/RssObjectPositionExtractor.cpp
 )
 
 set_target_properties(${PROJECT_NAME} PROPERTIES
@@ -200,3 +216,33 @@ if(BUILD_DOC)
     message(FATAL_ERROR, "Doxygen needs to be installed")
   endif()
 endif()
+
+
+################################################################################
+# Run clang-tidy to perform static code checks
+################################################################################
+
+if(BUILD_STATIC_ANALYSIS)
+
+  if(NOT EXISTS /usr/bin/clang-tidy)
+    message(FATAL_ERROR "Static code analysis requires clang-tidy to be installed in /usr/bin")
+  endif()
+
+  file(GLOB_RECURSE ALL_SOURCE_FILES src/*.cpp)
+
+  add_custom_target(
+    clang-tidy
+    COMMAND /usr/bin/clang-tidy
+    ${ALL_SOURCE_FILES}
+    -config=''
+    -header-filter=.*
+    -export-fixes=${CMAKE_CURRENT_SOURCE_DIR}/build/clangtidy.yml
+    --
+    -std=c++11
+    -I${CMAKE_CURRENT_SOURCE_DIR}/include/
+    -I${CMAKE_CURRENT_SOURCE_DIR}/include/generated/
+    -I${CMAKE_CURRENT_SOURCE_DIR}/src/
+    -I${CMAKE_CURRENT_SOURCE_DIR}/src/generated/
+  )
+endif()
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,21 +115,6 @@ add_library(${PROJECT_NAME} SHARED
   ${GENERATED_SOURCES}
 )
 
-set(ALL_SOURCES
-  ${GENERATED_SOURCES}
-  src/core/RssCheck.cpp
-  src/core/RssResponseResolving.cpp
-  src/core/RssResponseTransformation.cpp
-  src/core/RssSituationChecking.cpp
-  src/core/RssSituationExtraction.cpp
-  src/physics/Math.cpp
-  src/situation/RSSFormulas.cpp
-  src/situation/RssIntersectionChecker.cpp
-  src/situation/RSSSituation.cpp
-  src/world/RssSituationCoordinateSystemConversion.cpp
-  src/world/RssObjectPositionExtractor.cpp
-)
-
 set_target_properties(${PROJECT_NAME} PROPERTIES
   OUTPUT_NAME ad-rss
   VERSION ${PROJECT_VERSION}

--- a/README.md
+++ b/README.md
@@ -119,3 +119,11 @@ ad_rss$> sudo apt-get install clang-format-3.9
 ad_rss$> find -iname *.cpp -o -iname *.hpp | xargs clang-format-3.9 -style=file -i
 ```
 This command will automatically update the code formatting to be compliant with our style.
+
+In addition, please perform a static code analysis, if possible.
+```bash
+ad_rss$> sudo apt-get install clang-tidy
+ad_rss$> cmake -DBUILD_STATIC_ANALYSIS=ON
+ad_rss$> make clang-tidy
+```
+This may provide a list of possible improvements that you would like to consider in your pull request.

--- a/include/ad_rss/core/RssResponseResolving.hpp
+++ b/include/ad_rss/core/RssResponseResolving.hpp
@@ -67,14 +67,13 @@ public:
   /**
    * @brief Calculate the proper response out of the current responses
    *
-   * @param[in]  currentResponseStates all the response states gathered for the current situations
+   * @param[in]  currentStates all the response states gathered for the current situations
    * @param[out] responseState the proper overall response state
    *
    * @return true if response could be calculated, false otherwise
    * If false is returned the internal state has not been updated
    */
-  bool provideProperResponse(state::ResponseStateVector const &currentResponseStates,
-                             state::ResponseState &responseState);
+  bool provideProperResponse(state::ResponseStateVector const &currentStates, state::ResponseState &responseState);
 
 private:
   struct RssState

--- a/include/ad_rss/core/RssSituationChecking.hpp
+++ b/include/ad_rss/core/RssSituationChecking.hpp
@@ -48,7 +48,7 @@ namespace ad_rss {
  */
 namespace situation {
 class RssIntersectionChecker;
-}
+} // namespace situation
 
 /*!
  * @brief namespace core
@@ -90,13 +90,13 @@ private:
    *
    * @param[in] situation      the Situation that should be analyzed
    * @param[in] nextTimeStep   indidicates that a new time step occurred
-   * @param[out] responseState the response state for the current situation
+   * @param[out] response      the response state for the current situation
    *
    * @return true if situation could be analyzed, false if there was an error during evaluation
    */
   bool checkSituationInputRangeChecked(situation::Situation const &situation,
                                        bool const nextTimeStep,
-                                       state::ResponseState &responseState);
+                                       state::ResponseState &response);
 
   /*!
    * @brief check to ensure situation time is consistent

--- a/src/core/RssSituationChecking.cpp
+++ b/src/core/RssSituationChecking.cpp
@@ -173,22 +173,13 @@ bool RssSituationChecking::checkTimeIncreasingConsistently(situation::Situation 
   }
 
   bool timeIsIncreasing = false;
-  if (mCurrentTimeIndex == mLastTimeIndex)
-  {
-    // time is standing still
-    timeIsIncreasing = false;
-  }
-  else
+  if (mCurrentTimeIndex != mLastTimeIndex)
   {
     // check for overflow
     physics::TimeIndex const deltaTimeIndex = mCurrentTimeIndex - mLastTimeIndex;
     if (deltaTimeIndex < (std::numeric_limits<physics::TimeIndex>::max() / 2))
     {
       timeIsIncreasing = true;
-    }
-    else
-    {
-      timeIsIncreasing = false;
     }
   }
   return timeIsIncreasing;


### PR DESCRIPTION
#### Description
Static code analysis can now be performed running clang-tidy.

mkdir build
cd build
cmake .. -DBUILD_STATIC_ANALYSIS=ON
make clang-tidy

Checks are also run on Travis.

Checklist:
  - [x] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [x] Extended the README / documentation, if necessary
  - [x] Code compiles correctly and runs
  - [x] Code is formatted using clang-3.9 and the provided format file
  - [x] Changelog is updated


#### Where has this been tested?
  * **Platform(s):** Ubuntu 16.04 + Travis
  * **Library version:** 1.2.0

#### Possible Drawbacks
None

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel/ad-rss-lib/32)
<!-- Reviewable:end -->
