### PR TITLE
Fixed docu of lane ordering within a RoadSegment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Latest changes
 * Small updates to be compliant to clang-tidy-3.8 static code analysis
 * Added basic FAQ
+* Fixed documentation of RoadArea LaneSegment ordering (left -> right)
 
 ## Release 1.2.0
 * Added support for Clang 5 and Clang 6

--- a/doc/images/rss_situation_based_coordinate_system_creation_road_area.svg
+++ b/doc/images/rss_situation_based_coordinate_system_creation_road_area.svg
@@ -16,7 +16,7 @@
    width="1035.3065"
    height="296.65762"
    viewBox="0 0 1035.3065 296.65762"
-   sodipodi:docname="rss_situation_based_coordinate_system.svg.2019_01_28_14_47_46.0.svg"
+   sodipodi:docname="rss_situation_based_coordinate_system_creation_road_area.svg"
    inkscape:export-xdpi="90"
    inkscape:export-ydpi="90">
   <metadata
@@ -93,7 +93,7 @@
      id="namedview4"
      showgrid="true"
      inkscape:zoom="1.5581493"
-     inkscape:cx="558.19293"
+     inkscape:cx="449.41003"
      inkscape:cy="245.89162"
      inkscape:window-x="55"
      inkscape:window-y="24"
@@ -310,14 +310,14 @@
   <text
      xml:space="preserve"
      style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     x="84.361366"
-     y="268.51251"
+     x="85.003151"
+     y="145.2894"
      id="text4649-0"
      sodipodi:linespacing="125%"><tspan
        sodipodi:role="line"
        id="tspan4651-7"
-       x="84.361366"
-       y="268.51251"
+       x="85.003151"
+       y="145.2894"
        style="font-size:20px">0</tspan></text>
   <text
      xml:space="preserve"
@@ -334,14 +334,14 @@
   <text
      xml:space="preserve"
      style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     x="85.257568"
-     y="144.00583"
+     x="84.615776"
+     y="258.24393"
      id="text4649-63-1"
      sodipodi:linespacing="125%"><tspan
        sodipodi:role="line"
        id="tspan4651-76-5"
-       x="85.257568"
-       y="144.00583"
+       x="84.615776"
+       y="258.24393"
        style="font-size:20px">2</tspan></text>
   <text
      xml:space="preserve"

--- a/doc/includes/HLD-SwArchitecture.adoc
+++ b/doc/includes/HLD-SwArchitecture.adoc
@@ -383,7 +383,7 @@ the RssArea it belongs to.
 ====== RoadSegment (Typedef)
 
 A RoadSegment is defined by lateral neighboring lane segments. The lane segments within a road segment have to be
-ordered from right to left in respect to the driving direction defined by the road area.
+ordered from left to right in respect to the driving direction defined by the road area.
 
 |====
 |ad_rss::world::LaneSegment |[ * ]

--- a/include/generated/ad_rss/world/RoadSegment.hpp
+++ b/include/generated/ad_rss/world/RoadSegment.hpp
@@ -55,7 +55,7 @@ namespace world {
  * \brief DataType RoadSegment
  *
  * A RoadSegment is defined by lateral neighboring lane segments. The lane segments within a road segment have to be
- * ordered from right to left in respect to the driving direction defined by the road area.
+ * ordered from left to right in respect to the driving direction defined by the road area.
  */
 using RoadSegment = std::vector<::ad_rss::world::LaneSegment>;
 


### PR DESCRIPTION
Lane segements are ordered from left to right in driving direction.
The same direction as the lateral axis is defined.

<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [X] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [X] Extended the README / documentation, if necessary
  - [X] Code compiles correctly and runs
  - [X] Code is formatted using clang-3.9 and the provided format file
  - [X] Changelog is updated

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->

Fixes #  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):** ...
  * **Library version:** ...

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel/ad-rss-lib/34)
<!-- Reviewable:end -->
