### PR TITLE
Reworked usage of GTest in CMakeLists

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,6 @@ matrix:
           packages:
             - cmake
             - build-essential
-            - libgtest-dev
             - lcov
       script:
         - bash .github/.travis/compile.sh release
@@ -65,7 +64,6 @@ matrix:
           packages:
             - cmake
             - build-essential
-            - libgtest-dev
       script:
         - bash .github/.travis/compile.sh release
       after_failure:
@@ -77,7 +75,6 @@ matrix:
           packages:
             - cmake
             - build-essential
-            - libgtest-dev
             - doxygen
             - graphviz
             - asciidoctor
@@ -113,7 +110,6 @@ matrix:
           packages:
             - cmake
             - build-essential
-            - libgtest-dev
             - lcov
             - clang-tidy
             - clang-3.8
@@ -135,7 +131,6 @@ matrix:
           packages:
             - cmake
             - build-essential
-            - libgtest-dev
             - lcov
             - doxygen
             - graphviz
@@ -172,11 +167,11 @@ matrix:
         - docker run -d --name ubuntu -v $(pwd):/travis -w /travis ubuntu:trusty tail -f /dev/null
         - docker ps
       install:
-        - $SH "apt-get update && apt-get -y install build-essential cmake3 libgtest-dev clang"
+        - $SH "apt-get update && apt-get -y -qq install build-essential cmake3 clang git"
       script:
         - $SH "mkdir build && cd build && cmake .. -DBUILD_HARDENING=ON -DCMAKE_BUILD_TYPE=Release && make && ctest"
         - $SH "rm -rf build && export CC=/usr/bin/clang && export CXX=/usr/bin/clang++ && mkdir build && cd build && cmake .. -DBUILD_HARDENING=ON -DCMAKE_BUILD_TYPE=Release && make && ctest"
-        - $SH "apt-get -y remove clang && apt-get -y install clang-3.9"
+        - $SH "apt-get -y -qq remove clang && apt-get -y -qq install clang-3.9"
         - $SH "rm -rf build && export CC=/usr/bin/clang-3.9 && export CXX=/usr/bin/clang++-3.9 && mkdir build && cd build && cmake .. -DBUILD_HARDENING=ON -DCMAKE_BUILD_TYPE=Release && make && ctest"
       after_failure:
         - tail --lines=2000 build.log
@@ -191,13 +186,14 @@ matrix:
         - docker run -d --name ubuntu -v $(pwd):/travis -w /travis ubuntu:xenial tail -f /dev/null
         - docker ps
       install:
-        - $SH "apt-get update && apt-get -y install build-essential cmake libgtest-dev clang"
-        - $SH "apt-get -y install software-properties-common && add-apt-repository ppa:ubuntu-toolchain-r/test -y && apt-get update"
+        - $SH "apt-get update && apt-get -y -qq install build-essential cmake clang git"
+        - $SH "apt-get -y -qq install software-properties-common && add-apt-repository ppa:ubuntu-toolchain-r/test -y && apt-get update"
       script:
         - $SH "mkdir build && cd build && cmake .. -DBUILD_HARDENING=ON -DCMAKE_BUILD_TYPE=Release && make && ctest"
         - $SH "rm -rf build && export CC=/usr/bin/clang && export CXX=/usr/bin/clang++ && mkdir build && cd build && cmake .. -DBUILD_HARDENING=ON -DCMAKE_BUILD_TYPE=Release && make && ctest"
-        - $SH "apt-get -y remove clang && apt-get -y install clang-6.0 g++-6 clang-5.0"
+        - $SH "apt-get -y -qq remove clang && apt-get -y -qq install clang-6.0 g++-6 clang-5.0 g++-7"
         - $SH "rm -rf build && export CC=/usr/bin/gcc-6 && export CXX=/usr/bin/g++-6 && mkdir build && cd build && cmake .. -DBUILD_HARDENING=ON -DCMAKE_BUILD_TYPE=Release && make && ctest"
+        - $SH "rm -rf build && export CC=/usr/bin/gcc-7 && export CXX=/usr/bin/g++-7 && mkdir build && cd build && cmake .. -DBUILD_HARDENING=ON -DCMAKE_BUILD_TYPE=Release && make && ctest"
         - $SH "rm -rf build && export CC=/usr/bin/clang-5.0 && export CXX=/usr/bin/clang++-5.0 && mkdir build && cd build && cmake .. -DBUILD_HARDENING=ON -DCMAKE_BUILD_TYPE=Release && make && ctest"
         - $SH "rm -rf build && export CC=/usr/bin/clang-6.0 && export CXX=/usr/bin/clang++-6.0 && mkdir build && cd build && cmake .. -DBUILD_HARDENING=ON -DCMAKE_BUILD_TYPE=Release && make && ctest"
       after_failure:
@@ -213,10 +209,10 @@ matrix:
         - docker run -d --name ubuntu -v $(pwd):/travis -w /travis ubuntu:bionic tail -f /dev/null
         - docker ps
       install:
-        - $SH "apt-get update && apt-get -y install build-essential cmake libgtest-dev clang"
+        - $SH "apt-get update && apt-get -y -qq install build-essential cmake clang git"
       script:
         - $SH "mkdir build && cd build && cmake .. -DBUILD_HARDENING=ON -DCMAKE_BUILD_TYPE=Release && make && ctest"
-        #- $SH "rm -rf build && export CC=/usr/bin/clang && export CXX=/usr/bin/clang++ && mkdir build && cd build && cmake .. -DBUILD_HARDENING=ON -DCMAKE_BUILD_TYPE=Release && make && ctest"
+        - $SH "rm -rf build && export CC=/usr/bin/clang && export CXX=/usr/bin/clang++ && mkdir build && cd build && cmake .. -DBUILD_HARDENING=ON -DCMAKE_BUILD_TYPE=Release && make && ctest"
       after_failure:
         - tail --lines=2000 build.log
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Added basic FAQ
 * Added official support for Ubuntu 14.04 (GCC 4.8, Clang 3.4 and 3.8/3.9)
 * Added official support for Ubuntu 18.04 (GCC 7.3)
+* Download/Build gtest on the fly rather than using the version from the OS
 * Fixed documentation of RoadArea LaneSegment ordering (left -> right)
 * Fixed isSafe flags of the resolved response
 * Renamed some internal files from 'RSS...' -> 'Rss...' to have camel-case everywhere

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,17 +173,14 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
 if(BUILD_TESTING)
 message(STATUS "Build Testing")
   enable_testing()
-  if(NOT TARGET GTest::GTest)
-    find_package(GTest QUIET)
-    if (NOT GTEST_FOUND)
-      #As Ubuntu never ships precompiled gtest libraries, build them on-the-fly from source
-      #requires gtest-dev package to be intalled
-      add_subdirectory(/usr/src/gtest gtest)
-      add_library(GTest::GTest ALIAS gtest)
-      add_library(GTest::Main ALIAS gtest_main)
-    endif()
-  endif()
- add_subdirectory(tests)
+
+  configure_file(tests/gtest-cmake.txt.in googletest-download/CMakeLists.txt)
+  execute_process(COMMAND "${CMAKE_COMMAND}" -G "Eclipse CDT4 - Unix Makefiles" . RESULT_VARIABLE result WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/googletest-download")
+  execute_process(COMMAND "${CMAKE_COMMAND}" --build . RESULT_VARIABLE result WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/googletest-download")
+  add_subdirectory("${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
+                   "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
+                   EXCLUDE_FROM_ALL)
+  add_subdirectory(tests)
 endif()
 
 

--- a/README.md
+++ b/README.md
@@ -70,10 +70,10 @@ Note: The RSS module in this library does not initiate evasive manuevers. At the
 ## Getting started <a name="started"></a>
 
 ### Installation of dependencies
-Currently, the focued operating system is Ubuntu 16.04. Nevertheless, the library should work in a similar way for any other Linux OS.
+Currently, the focused operating system is Ubuntu 16.04. Nevertheless, the library should work in a similar way for any other Linux OS.
 To install the dependencies for Ubuntu 16.04 execute the following command:
 ```bash
- user$> sudo apt-get install git build-essential cmake libgtest-dev
+ user$> sudo apt-get install git build-essential cmake 
 ```
 
 If you want to use doxygen for API documentation, please also install:
@@ -89,18 +89,20 @@ To download the library, you may run:
 ```
 
 ### Supported systems <a name="systems"></a>
-Besides Ubuntu 16.04 we are currently supporting the following Linux OS and compiler combinations
+Besides Ubuntu 16.04 we are currently supporting the following Linux OS and compiler combinations:
 
 |                 | Ubuntu 14.04 | Ubuntu 16.04 | Ubuntu 18.04 |
 |:---------------:|:------------:|:------------:|:------------:|
 |  Clang 3.4      |       x      |              |              |
 |  Clang 3.8/3.9  |       x      |       x      |              |
 |  Clang 5.0      |              |       x      |              |
-|  Clang 6.0      |              |       x      |       -      |
+|  Clang 6.0      |              |       x      |       x      |
 |   GCC 4.8       |       x      |              |              |
 | GCC 5.4/5.5     |              |       x      |              |
 |   GCC 6.0       |              |       x      |              |
 |   GCC 7.3       |              |       x      |       x      |
+
+Important: cmake is required to be at least version 3.5!
 
 ## Building the library <a name="building"></a>
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -95,7 +95,7 @@ target_include_directories(${EXEC_NAME}
 )
 
 target_link_libraries(${EXEC_NAME} PRIVATE
-  GTest::Main
+  gtest_main
   ${PROJECT_NAME}
 )
 

--- a/tests/generated/world/ObjectValidInputRangeTests.cpp
+++ b/tests/generated/world/ObjectValidInputRangeTests.cpp
@@ -755,6 +755,7 @@ TEST(ObjectValidInputRangeTests, testValidInputRangeResponseTimeTooBig)
 TEST(ObjectValidInputRangeTests, testValidInputRangeresponseTimeDefault)
 {
   ::ad_rss::world::Object value;
+  value.objectType = ::ad_rss::world::ObjectType::EgoVehicle;
   ::ad_rss::physics::Duration valueDefault;
   value.responseTime = valueDefault;
   ASSERT_FALSE(withinValidInputRange(value));

--- a/tests/gtest-cmake.txt.in
+++ b/tests/gtest-cmake.txt.in
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(googletest-download NONE)
+
+include(ExternalProject)
+ExternalProject_Add(googletest-download
+  GIT_REPOSITORY https://github.com/google/googletest.git
+  GIT_TAG release-1.7.0
+  SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/googletest-src
+  BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/googletest-build
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND ""
+  INSTALL_COMMAND ""
+  TEST_COMMAND ""
+)
+


### PR DESCRIPTION
#### Description
GTest is now automatically downloaded from github to remove external
dependencies. This also allows us to use a fixed version independent of
the OS supported version of gtest.

Others:
- Full support of Clang 6 under 18.04
- Removed libgtest-dev dependency

Fixes #38 

Checklist:
  - [x] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [x] Extended the README / documentation, if necessary
  - [x] Code compiles correctly and runs
  - [x] Code is formatted using clang-3.9 and the provided format file
  - [x] Changelog is updated

#### Where has this been tested?
  * **Platform(s):** Travis
  * **Library version:** 1.2

#### Possible Drawbacks
None

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel/ad-rss-lib/39)
<!-- Reviewable:end -->
