### PR TITLE
Add option to select library build type (static/dynamic)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Latest changes
-
+* Add option to select library build type (static/dynamic)
 ## Release 1.3.0
 * Allow multiple situations per ego vehicle/object pair: Add RssSituationIdProvider and made RssSituationExtraction a class holding RssSituationIdProvider instance to keep track of the different situation classes
 * Renamed world::Dynamics in world::RssDynamics, extended it by responseTime and separated it from world::Object; world::Scene got the objectRssDynamics and world::WorldModel the egoVehicleRssDynamics each as separate elements

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,8 @@ set(BUILD_HARDENING "OFF" CACHE BOOL "Enable build hardening flags")
 set(BUILD_COVERAGE "OFF" CACHE BOOL "Enable test coverage")
 set(BUILD_STATIC_ANALYSIS "OFF" CACHE BOOL "Enable static code analysis")
 
+option(BUILD_SHARED_LIBS "Libraries will be built as shared libraries" On)
+
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 project(ad-rss-lib VERSION 1.3.0)
@@ -104,7 +106,7 @@ set(GENERATED_SOURCES
   src/generated/world/ObjectType.cpp
 )
 
-add_library(${PROJECT_NAME} SHARED
+add_library(${PROJECT_NAME}
   src/core/RssCheck.cpp
   src/core/RssResponseResolving.cpp
   src/core/RssResponseTransformation.cpp
@@ -178,6 +180,8 @@ message(STATUS "Build Testing")
   configure_file(tests/gtest-cmake.txt.in googletest-download/CMakeLists.txt)
   execute_process(COMMAND "${CMAKE_COMMAND}" -G "Eclipse CDT4 - Unix Makefiles" . RESULT_VARIABLE result WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/googletest-download")
   execute_process(COMMAND "${CMAKE_COMMAND}" --build . RESULT_VARIABLE result WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/googletest-download")
+
+  set(BUILD_SHARED_LIBS OFF)
   add_subdirectory("${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
                    "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
                    EXCLUDE_FROM_ALL)


### PR DESCRIPTION
ad-rss library can now be built as dynamic or static library.
Default remains dynamic library as it was before.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel/ad-rss-lib/41)
<!-- Reviewable:end -->
