### PR TITLE
Fixed doxygen link and version number in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ In addition, the terms in the following apply:
 
 ## Documentation
 Visit the project's [GitHub page](https://intel.github.io/ad-rss-lib/) to access the online version of the full documentation of this library. This includes:
-- [Doxygen](https://intel.github.io/ad-rss-lib/doxygen/index.html)
+- [Doxygen](https://intel.github.io/ad-rss-lib/doxygen/html/index.html)
 - [Background documentation](https://intel.github.io/ad-rss-lib/documentation/Main.html).
 
 If you have any additional question not answered therein, you might find more in:

--- a/doc/Main.adoc
+++ b/doc/Main.adoc
@@ -26,7 +26,7 @@ ad-rss-lib
 :pdf-style: custom
 :pdf-fontsdir: /var/lib/gems/2.3.0/gems/asciidoctor-pdf-1.5.0.alpha.16/data/fonts
 // html ressources
-:revnumber: 1.2
+:revnumber: 1.5
 :revdate: {localdate}
 :stylesheet: documentation_style.css
 :stylesdir: ./resources/css


### PR DESCRIPTION
Fixes #52 


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel/ad-rss-lib/51)
<!-- Reviewable:end -->
