### PR TITLE
Added ObjectIdVector support to Python binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 ## Latest changes
+#### :ghost: Maintenance
+* Added ObjectIDVector support to Python binding
 
 ## Release 1.6.0
+#### :rocket: New Features
 * Added Python binding
 
 ## Release 1.5.0
+#### :ghost: Maintenance
 * License change to LGPL v2.1
 
 ## Release 1.4.0

--- a/python/PythonWrapper.cpp
+++ b/python/PythonWrapper.cpp
@@ -1437,6 +1437,11 @@ BOOST_PYTHON_MODULE(libad_rss_python){
         ProperResponse_exposer.def_readwrite( "timeIndex", &ad_rss::state::ProperResponse::timeIndex );
     }
 
+    {
+        bp::class_< ::ad_rss::world::ObjectIdVector >("ObjectVector")
+            .def(bp::vector_indexing_suite<::ad_rss::world::ObjectIdVector>() );
+    }
+
     { //::ad_rss::state::RssState
         typedef bp::class_< ad_rss::state::RssState > RssState_exposer_t;
         RssState_exposer_t RssState_exposer = RssState_exposer_t( "RssState", bp::init< >() );


### PR DESCRIPTION
Added ObjectIdVector support to Python binding.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel/ad-rss-lib/54)
<!-- Reviewable:end -->
