### PR TITLE
Error in ParameterDiscussion.md, $\alpha_{brake,min}$ twice on table

### DIFF
--- a/doc/ad_rss/Appendix-ParameterDiscussion.md
+++ b/doc/ad_rss/Appendix-ParameterDiscussion.md
@@ -186,7 +186,7 @@ fluctuations, but will not have a big impact on the safety distance.
     | $\rho_{other}$                  | $2s$          |
     | $\alpha_{accel,max}$            | $3.5m/s^2$    |
     | $\alpha_{brake,min}$            | $4m/s^2$      |
-    | $\alpha_{brake,min}$            | $8m/s^2$      |
+    | $\alpha_{brake,max}$            | $8m/s^2$      |
     | $\alpha_{brake,min,correct}$    | $3m/s^2$      |
     | $\alpha^{lat}_{brake,min}$      | $0.8m/s^2$    |
     | $\alpha^{lat}_{accel,max}$      | $0.2m/s^2$    |


### PR DESCRIPTION
$\alpha_{brake,min}$ was mistakenly put in the table twice , whereas instead it should be:
    | $\alpha_{brake,min}$            | $4m/s^2$      |
    | $\alpha_{brake,max}$            | $8m/s^2$      |

<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly and runs
  - [ ] Code is formatted using clang-3.9 and the provided format file
  - [ ] Changelog is updated

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->

Fixes #  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):** ...
  * **Library version:** ...

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel/ad-rss-lib/59)
<!-- Reviewable:end -->
