### PR TITLE
Update pedestrian trajectory calculation

### DIFF
--- a/ad_rss/impl/include/ad/rss/unstructured/Geometry.hpp
+++ b/ad_rss/impl/include/ad/rss/unstructured/Geometry.hpp
@@ -204,6 +204,17 @@ void calculateCircleArc(Point origin,
 bool collides(world::UnstructuredTrajectorySet const &trajectorySet1,
               world::UnstructuredTrajectorySet const &trajectorySet2);
 
+/**
+ * @brief Combine two polygons
+ *
+ * @param[in]  a       polygon a
+ * @param[in]  b       polygon b
+ * @param[out] result  resulting polygon
+ *
+ * @returns false if a failure occurred during calculations, true otherwise
+ */
+bool combinePolygon(Polygon const &a, Polygon const &b, Polygon &result);
+
 } // namespace unstructured
 } // namespace rss
 } // namespace ad

--- a/ad_rss/impl/src/unstructured/Geometry.cpp
+++ b/ad_rss/impl/src/unstructured/Geometry.cpp
@@ -172,6 +172,34 @@ bool getHeadingOverlap(ad::rss::state::HeadingRange const &headingRange,
   return !overlapRanges.empty();
 }
 
+bool combinePolygon(Polygon const &a, Polygon const &b, Polygon &result)
+{
+  if (a.outer().empty() && !b.outer().empty())
+  {
+    result = b;
+  }
+  else if (!a.outer().empty() && b.outer().empty())
+  {
+    result = a;
+  }
+  else
+  {
+    std::vector<Polygon> unionPolygons;
+    boost::geometry::union_(a.outer(), b.outer(), unionPolygons);
+    if (unionPolygons.size() != 1)
+    {
+      spdlog::debug("Could not calculate combined polygon. Expected 1 polygon after union, found {}",
+                    unionPolygons.size());
+      return false;
+    }
+    else
+    {
+      result = std::move(unionPolygons[0]);
+    }
+  }
+  return true;
+}
+
 } // namespace unstructured
 } // namespace rss
 } // namespace ad

--- a/ad_rss/impl/src/unstructured/TrajectoryCommon.hpp
+++ b/ad_rss/impl/src/unstructured/TrajectoryCommon.hpp
@@ -96,6 +96,23 @@ struct TrajectoryPoint
   physics::AngularVelocity yawRate;
 };
 
+struct TrajectorySetStep
+{
+  TrajectorySetStep()
+  {
+  }
+
+  TrajectorySetStep(TrajectoryPoint const &inLeft, TrajectoryPoint const &inRight, TrajectoryPoint const &inCenter)
+    : center(inCenter)
+  {
+    left.push_back(inLeft);
+    right.push_back(inRight);
+  }
+  std::vector<TrajectoryPoint> left;  // with positive yaw rate ratio
+  std::vector<TrajectoryPoint> right; // with negative yaw rate ratio
+  TrajectoryPoint center;
+};
+
 /**
  * @brief get the point describing the corner of a vehicle
  *

--- a/ad_rss/impl/src/unstructured/TrajectoryPedestrian.cpp
+++ b/ad_rss/impl/src/unstructured/TrajectoryPedestrian.cpp
@@ -27,7 +27,8 @@ namespace rss {
 namespace unstructured {
 
 const ad::physics::Distance TrajectoryPedestrian::maxRadius(1000.);
-const ad::physics::Angle TrajectoryPedestrian::circleStepWidth(0.1);
+const ad::physics::Angle TrajectoryPedestrian::circleStepWidth(physics::c2PI/20.);
+
 
 bool TrajectoryPedestrian::calculateTrajectorySets(situation::VehicleState const &vehicleState,
                                                    Polygon &brakePolygon,
@@ -38,97 +39,474 @@ bool TrajectoryPedestrian::calculateTrajectorySets(situation::VehicleState const
                                                vehicleState.dynamics.responseTime,
                                                vehicleState.dynamics.maxSpeedOnAcceleration,
                                                vehicleState.dynamics.alphaLon.accelMax,
-                                               vehicleState.dynamics.alphaLon.brakeMax,
+                                               vehicleState.dynamics.alphaLon.brakeMin,
                                                timeToStop);
-  if (result)
-  {
-    result = createTrajectorySet(vehicleState, timeToStop, vehicleState.dynamics.alphaLon.brakeMin, brakePolygon);
-  }
-  if (result)
-  {
-    result
-      = createTrajectorySet(vehicleState, timeToStop, vehicleState.dynamics.alphaLon.accelMax, continueForwardPolygon);
-  }
-  return result;
-}
 
-bool TrajectoryPedestrian::createTrajectorySet(situation::VehicleState const &vehicleState,
-                                               ad::physics::Duration const &duration,
-                                               ad::physics::Acceleration const &aAfterResponseTime,
-                                               Polygon &trajectorySet)
-{
-  auto result = true;
-  if (vehicleState.objectState.speed != ad::physics::Speed(0.))
+  if (result)
   {
-    Trajectory frontPts;
-    for (auto i = ad::physics::RatioValue(1.0); i >= ad::physics::RatioValue(-1.0); i -= ad::physics::RatioValue(0.1))
+    if (vehicleState.objectState.speed == ad::physics::Speed(0.))
     {
-      auto endPt = getFinalTrajectoryPoint(vehicleState,
-                                           duration,
-                                           vehicleState.dynamics.alphaLon.accelMax,
-                                           aAfterResponseTime,
-                                           i,
-                                           std::to_string(aAfterResponseTime) + "_" + std::to_string(i));
-      frontPts.push_back(endPt);
-#if DEBUG_DRAWING
-      DEBUG_DRAWING_POLYGON(TrafficParticipantLocation(endPt, vehicleState).toPolygon(),
-                            "yellow",
-                            std::to_string(aAfterResponseTime) + "_" + std::to_string(i) + "_vehicle_final_position");
-#endif
-    }
-    auto frontPolygon = calculateFrontWithDimension(frontPts, vehicleState.objectState.dimension);
-    auto backPolygon = calculateBackWithDimension(vehicleState, duration, aAfterResponseTime);
-    std::vector<Polygon> unionPolygons;
-    boost::geometry::union_(frontPolygon.outer(), backPolygon.outer(), unionPolygons);
-    if (unionPolygons.size() != 1)
-    {
-      return false;
+      result = calculateTrajectorySetsStandingStill(vehicleState, timeToStop, brakePolygon, continueForwardPolygon);
     }
     else
     {
-      trajectorySet = unionPolygons[0];
+      result = calculateTrajectorySetsMoving(vehicleState, timeToStop, brakePolygon, continueForwardPolygon);
     }
+  }
+#if DEBUG_DRAWING
+  DEBUG_DRAWING_POLYGON(brakePolygon, "red", "brake_pedestrian");
+  DEBUG_DRAWING_POLYGON(continueForwardPolygon, "green", "continueForward_pedestrian");
+#endif
+  return result;
+}
+
+bool TrajectoryPedestrian::calculateTrajectorySetsMoving(situation::VehicleState const &vehicleState,
+      physics::Duration const &timeToStop,
+                                                   Polygon &brakePolygon,
+                                                   Polygon &continueForwardPolygon) const
+{ 
+  TrajectorySetStep responseTimeFrontSide;
+  TrajectorySetStep responseTimeBackSide;
+  auto result = getResponseTimeTrajectoryPoints(vehicleState, responseTimeFrontSide, responseTimeBackSide);
+  if (!result)
+  {
+    spdlog::debug("TrajectoryPedestrian::calculateTrajectorySets>> Could not calculate reponse time trajectory points.");
   }
   else
   {
-    // If pedestrian is standing, he might start walking in any direction
-    ad::physics::Speed speed;
-    ad::physics::Distance maxDistance;
-    result = situation::calculateSpeedAndDistanceOffset(duration,
+    spdlog::trace(
+      "Trajectory points at response time: front left {}, front right {}, back left {}, back right {}",
+      responseTimeFrontSide.left.size(),
+      responseTimeFrontSide.right.size(),
+      responseTimeBackSide.left.size(),
+      responseTimeBackSide.right.size());
+  }
+
+  auto timeAfterResponseTime = timeToStop - vehicleState.dynamics.responseTime;
+
+  auto timeToStopBrakeMax = physics::Duration(0.);
+  if (responseTimeBackSide.center.speed > physics::Speed(0.))
+  {
+    result = situation::calculateTimeToStop(responseTimeBackSide.center.speed,
+                                            timeAfterResponseTime, //this is the time to stop with brakemin, therefore sufficient here
+                                            vehicleState.dynamics.maxSpeedOnAcceleration,
+                                            vehicleState.dynamics.alphaLon.brakeMax,
+                                            vehicleState.dynamics.alphaLon.brakeMax,
+                                            timeToStopBrakeMax);
+    if (!result)
+    {
+      spdlog::debug(
+        "TrajectoryPedestrian::calculateTrajectorySets>> Could not calculate time to stop. speed {}, timeAfterResponseTime {}",
+        responseTimeBackSide.center.speed,
+        timeAfterResponseTime);
+    }
+  }
+  
+  physics::Distance maxBrakeDistance = physics::Distance(0.);
+  if (result)
+  {
+    physics::Speed speed;
+    result = situation::calculateSpeedAndDistanceOffset(timeToStopBrakeMax,
+                                              responseTimeBackSide.center.speed,
+                                              timeToStopBrakeMax,
+                                              vehicleState.dynamics.maxSpeedOnAcceleration,
+                                              vehicleState.dynamics.alphaLon.brakeMax,
+                                              vehicleState.dynamics.alphaLon.brakeMax,
+                                              speed,
+                                              maxBrakeDistance);
+  }
+
+  physics::Distance minBrakeDistance = physics::Distance(0.);
+  if (result)
+  {
+    physics::Speed speed;
+    result = situation::calculateSpeedAndDistanceOffset(timeAfterResponseTime,
+                                              responseTimeFrontSide.center.speed,
+                                              timeAfterResponseTime,
+                                              vehicleState.dynamics.maxSpeedOnAcceleration,
+                                              vehicleState.dynamics.alphaLon.brakeMin,
+                                              vehicleState.dynamics.alphaLon.brakeMin,
+                                              speed,
+                                              minBrakeDistance);
+    if (!result)
+    {
+      spdlog::debug("TrajectoryPedestrian::calculateTrajectorySets>> Could not calculate speed and distance offset for t={} and minBrake={}.", timeAfterResponseTime, vehicleState.dynamics.alphaLon.brakeMin);
+    }
+  }
+  
+  physics::Distance accelMaxDistance = physics::Distance(0.);
+  if (result)
+  {
+    physics::Speed speed;
+    result = situation::calculateSpeedAndDistanceOffset(timeAfterResponseTime,
+                                              responseTimeFrontSide.center.speed,
+                                              timeAfterResponseTime,
+                                              vehicleState.dynamics.maxSpeedOnAcceleration,
+                                              vehicleState.dynamics.alphaLon.accelMax,
+                                              vehicleState.dynamics.alphaLon.accelMax,
+                                              speed,
+                                              accelMaxDistance);
+    if (!result)
+    {
+      spdlog::debug("TrajectoryPedestrian::calculateTrajectorySets>> Could not calculate speed and distance offset for t={} and accelMax={}.", timeAfterResponseTime, vehicleState.dynamics.alphaLon.accelMax);
+    }
+  }
+
+  auto finalRightMinBrakeDistance = calculateFinalPoint(responseTimeFrontSide.right.front(), minBrakeDistance);
+  auto finalLeftMinBrakeDistance = calculateFinalPoint(responseTimeFrontSide.left.back(), minBrakeDistance);  
+  auto finalRightMaxBrakeDistance = calculateFinalPoint(responseTimeBackSide.right.front(), maxBrakeDistance);
+  auto finalLeftMaxBrakeDistance = calculateFinalPoint(responseTimeBackSide.left.back(), maxBrakeDistance);
+  //=======================
+  // calculate brakePolygon
+  //=======================
+  //-------------
+  // brake front
+  //-------------
+  if (result)
+  {
+    result = calculateStepPolygon(vehicleState,
+                                  minBrakeDistance,
+                                  responseTimeFrontSide,
+                                  "",//"brake_front",
+                                  brakePolygon);
+    if (!result)
+    {
+      spdlog::debug("TrajectoryPedestrian::calculateTrajectorySets>> Could not calculate brake max step polygon.");
+    }
+  }
+
+  //-------------
+  // brake sides
+  //-------------
+  Polygon brakeMaxBrakeMinLeftSidePolygon;
+  Polygon brakeMaxBrakeMinRightSidePolygon;
+  if (result)
+  {    
+    brakeMaxBrakeMinLeftSidePolygon = calculateSidePolygon(vehicleState,
+      finalLeftMaxBrakeDistance,
+      finalLeftMinBrakeDistance);
+    result = combinePolygon(brakeMaxBrakeMinLeftSidePolygon, brakePolygon, brakePolygon);
+  }
+  if (result)
+  {
+    brakeMaxBrakeMinRightSidePolygon = calculateSidePolygon(vehicleState,
+      finalRightMaxBrakeDistance,
+      finalRightMinBrakeDistance);
+    result = combinePolygon(brakeMaxBrakeMinRightSidePolygon, brakePolygon, brakePolygon);
+  }
+
+  //-------------
+  // brake back
+  //-------------
+  Polygon maxBrakePolygon;
+  if (result)
+  {
+    MultiPoint back;
+    boost::geometry::append(back, getVehicleCorner(finalRightMaxBrakeDistance, vehicleState.objectState.dimension, VehicleCorner::backRight));
+    boost::geometry::append(back, getVehicleCorner(finalRightMaxBrakeDistance, vehicleState.objectState.dimension, VehicleCorner::frontRight));
+    boost::geometry::append(back, getVehicleCorner(finalLeftMaxBrakeDistance, vehicleState.objectState.dimension, VehicleCorner::backLeft));
+    boost::geometry::append(back, getVehicleCorner(finalLeftMaxBrakeDistance, vehicleState.objectState.dimension, VehicleCorner::frontLeft));
+    boost::geometry::convex_hull(back, maxBrakePolygon);
+#if DEBUG_DRAWING
+    DEBUG_DRAWING_POLYGON(maxBrakePolygon, "red", "brake_back");
+#endif
+    combinePolygon(maxBrakePolygon, brakePolygon, brakePolygon);
+  }
+
+  //=================================
+  // calculate continueForwardPolygon
+  //=================================
+  //-------------
+  // continueForward front
+  //-------------
+  if (result)
+  {
+    result = calculateStepPolygon(vehicleState,
+                                  accelMaxDistance,
+                                  responseTimeFrontSide,
+                                  "continueForward_front",
+                                  continueForwardPolygon);
+    if (!result)
+    {
+      spdlog::debug("TrajectoryPedestrian::calculateTrajectorySets>> Could not calculate continueForward front polygon.");
+    }
+  }
+
+  //-------------
+  // continueForward sides
+  //-------------
+  if (result)
+  {    
+    auto accelMaxLeftSidePolygon = calculateSidePolygon(vehicleState,
+      finalLeftMinBrakeDistance,
+      calculateFinalPoint(responseTimeFrontSide.left.back(), accelMaxDistance));
+    result = combinePolygon(accelMaxLeftSidePolygon, continueForwardPolygon, continueForwardPolygon);
+  }
+  if (result)
+  {
+     auto accelMaxRightSidePolygon = calculateSidePolygon(vehicleState,
+      finalRightMinBrakeDistance,
+      calculateFinalPoint(responseTimeFrontSide.right.front(), accelMaxDistance));
+    result = combinePolygon(accelMaxRightSidePolygon, continueForwardPolygon, continueForwardPolygon);
+  }
+  if (result)
+  {
+    result = combinePolygon(brakeMaxBrakeMinLeftSidePolygon, continueForwardPolygon, continueForwardPolygon);
+  }
+  if (result)
+  {
+    result = combinePolygon(brakeMaxBrakeMinRightSidePolygon, continueForwardPolygon, continueForwardPolygon);
+  }
+
+  //---------------------
+  // continueForward back
+  //---------------------
+  if (result)
+  {
+    combinePolygon(maxBrakePolygon, continueForwardPolygon, continueForwardPolygon);
+    if (!result)
+    {
+      spdlog::debug("TrajectoryPedestrian::calculateTrajectorySets>> Error while combining back with continueForwardPolygon.");
+    }
+  }
+
+  return result;
+}
+
+
+bool TrajectoryPedestrian::calculateTrajectorySetsStandingStill(situation::VehicleState const &vehicleState,
+physics::Duration const &timeToStop,
+                                                   Polygon &brakePolygon,
+                                                   Polygon &continueForwardPolygon) const
+{
+ // If pedestrian is standing, he might start walking in any direction
+  ad::physics::Speed speed;
+  ad::physics::Distance brakeMinMaxDistance;
+  auto result = situation::calculateSpeedAndDistanceOffset(timeToStop,
+                                                      vehicleState.objectState.speed,
+                                                      vehicleState.dynamics.responseTime,
+                                                      vehicleState.dynamics.maxSpeedOnAcceleration,
+                                                      vehicleState.dynamics.alphaLon.accelMax,
+                                                      vehicleState.dynamics.alphaLon.brakeMin,
+                                                      speed,
+                                                      brakeMinMaxDistance);
+  calculateCircleArc(toPoint(vehicleState.objectState.centerPoint),
+                      brakeMinMaxDistance,
+                      ad::physics::Angle(0.),
+                      ad::physics::c2PI,
+                      circleStepWidth,
+                      brakePolygon);
+             
+    ad::physics::Distance accelMaxMaxDistance;     
+  if (result)
+  {
+    result = situation::calculateSpeedAndDistanceOffset(timeToStop,
                                                         vehicleState.objectState.speed,
                                                         vehicleState.dynamics.responseTime,
                                                         vehicleState.dynamics.maxSpeedOnAcceleration,
                                                         vehicleState.dynamics.alphaLon.accelMax,
-                                                        aAfterResponseTime,
+                                                        vehicleState.dynamics.alphaLon.accelMax,
                                                         speed,
-                                                        maxDistance);
+                                                        accelMaxMaxDistance);
     calculateCircleArc(toPoint(vehicleState.objectState.centerPoint),
-                       maxDistance,
-                       ad::physics::Angle(0.),
-                       ad::physics::c2PI,
-                       circleStepWidth,
-                       trajectorySet);
+                        accelMaxMaxDistance,
+                        ad::physics::Angle(0.),
+                        ad::physics::c2PI,
+                        circleStepWidth,
+                        continueForwardPolygon);
+  }
+  
+  return result;
+}
+
+Polygon TrajectoryPedestrian::calculateSidePolygon(situation::VehicleState const &vehicleState,
+                                            TrajectoryPoint const &finalPointMin,
+                                            TrajectoryPoint const &finalPointMax) const
+{
+    MultiPoint side;
+    boost::geometry::append(side, getVehicleCorner(finalPointMax, vehicleState.objectState.dimension, VehicleCorner::frontRight)); 
+    boost::geometry::append(side, getVehicleCorner(finalPointMax, vehicleState.objectState.dimension, VehicleCorner::frontLeft)); 
+    boost::geometry::append(side, getVehicleCorner(finalPointMin, vehicleState.objectState.dimension, VehicleCorner::backLeft)); 
+    boost::geometry::append(side, getVehicleCorner(finalPointMin, vehicleState.objectState.dimension, VehicleCorner::backRight));
+    
+    Polygon hull;
+    boost::geometry::convex_hull(side, hull);
+    return hull;
+}
+
+TrajectoryPoint TrajectoryPedestrian::calculateFinalPoint(TrajectoryPoint const &pointAfterResponseTime,
+                                                physics::Distance const &distance) const
+{
+  if (distance > physics::Distance(0.))
+  {
+    auto finalPoint = pointAfterResponseTime;
+    auto headingAngle = pointAfterResponseTime.angle - ad::physics::cPI_2;
+    finalPoint.position = pointAfterResponseTime.position + toPoint(-std::sin(headingAngle) * distance, std::cos(headingAngle) * distance);
+    return finalPoint;
+  }
+  else
+  {
+    return pointAfterResponseTime;
+  }
+}
+
+bool TrajectoryPedestrian::calculateStepPolygon(situation::VehicleState const &vehicleState,
+                                             physics::Distance const &distance,
+                                             TrajectorySetStep const &step,
+                                             std::string const &debugNamespace,
+                                            Polygon &polygon) const
+{
+  auto result = true;
+
+  //calculate final points
+  TrajectorySetStep finalStep;
+  if (distance > physics::Distance(0.))
+  {
+    for (auto const &left: step.left)
+    {
+      finalStep.left.push_back(calculateFinalPoint(left, distance));
+    }
+    for (auto const &right: step.right)
+    {
+      finalStep.right.push_back(calculateFinalPoint(right, distance));
+    }
+    finalStep.center = calculateFinalPoint(step.center, distance);
+  }
+  else
+  {
+    finalStep = step;
+  }
+
+  MultiPoint ptsLeft;
+  MultiPoint ptsRight;
+
+  auto finalCenterFrontLeft = getVehicleCorner(finalStep.center, vehicleState.objectState.dimension, VehicleCorner::frontLeft);
+  auto finalCenterFrontRight = getVehicleCorner(finalStep.center, vehicleState.objectState.dimension, VehicleCorner::frontRight);
+
+  //----
+  //left
+  //----
+#if DEBUG_DRAWING
+  int idx = 0;
+#endif
+  for (auto it = finalStep.left.begin(); (it != finalStep.left.end()) && result; ++it)
+  {
+#if DEBUG_DRAWING
+    auto vehicleLocation = TrafficParticipantLocation(*it, vehicleState);
+    DEBUG_DRAWING_POLYGON(vehicleLocation.toPolygon(), "black", debugNamespace + "_left_" + std::to_string(idx));
+    ++idx;
+#else
+    (void)debugNamespace;
+#endif
+    boost::geometry::append(ptsLeft, getVehicleCorner(*it, vehicleState.objectState.dimension, VehicleCorner::frontRight));
+    boost::geometry::append(ptsLeft, getVehicleCorner(*it, vehicleState.objectState.dimension, VehicleCorner::frontLeft));
+  }
+  boost::geometry::append(ptsLeft, finalCenterFrontLeft);
+  boost::geometry::append(ptsLeft, finalCenterFrontRight);
+
+  //-----
+  //right
+  //-----
+#if DEBUG_DRAWING
+  idx = 0;
+#endif
+  for (auto it = finalStep.right.begin(); (it != finalStep.right.end()) && result; ++it)
+  {
+#if DEBUG_DRAWING
+    auto vehicleLocation = TrafficParticipantLocation(*it, vehicleState);
+    DEBUG_DRAWING_POLYGON(vehicleLocation.toPolygon(), "black", debugNamespace + "_right_" + std::to_string(idx));
+    ++idx;
+#else
+    (void)debugNamespace;
+#endif
+    boost::geometry::append(ptsRight, getVehicleCorner(*it, vehicleState.objectState.dimension, VehicleCorner::frontLeft));
+    boost::geometry::append(ptsRight, getVehicleCorner(*it, vehicleState.objectState.dimension, VehicleCorner::frontRight));
+  }
+  boost::geometry::append(ptsRight, finalCenterFrontLeft);
+  boost::geometry::append(ptsRight, finalCenterFrontRight);
+
+
+  if (result)
+  {
+    Polygon hullLeft;
+    Polygon hullRight;
+    boost::geometry::convex_hull(ptsLeft, hullLeft);
+    boost::geometry::convex_hull(ptsRight, hullRight);
+    result = combinePolygon(hullLeft, hullRight, polygon);
   }
   return result;
 }
 
-TrajectoryPoint TrajectoryPedestrian::getFinalTrajectoryPoint(situation::VehicleState const &vehicleState,
-                                                              ad::physics::Duration const &duration,
-                                                              ad::physics::Acceleration const &aUntilResponseTime,
-                                                              ad::physics::Acceleration const &aAfterResponseTime,
-                                                              ad::physics::RatioValue const &angleChangeRatio,
-                                                              std::string const &debugNamespace) const
+bool TrajectoryPedestrian::getResponseTimeTrajectoryPoints(situation::VehicleState const &vehicleState,
+                                                        TrajectorySetStep &frontSide,
+                                                        TrajectorySetStep &backSide) const
 {
+  auto result = true;
+  //-------------
+  // back
+  //-------------
+  for (auto ratioValue = physics::RatioValue(-1.0); (ratioValue <= physics::RatioValue(1.0)) && result;
+       ratioValue += physics::RatioValue(0.1))
+  {
+    auto accel = vehicleState.dynamics.alphaLon.brakeMax;
+    TrajectoryPoint pt;
+    result = getResponseTimeTrajectoryPoint(vehicleState, accel, ratioValue, pt);
+    if (ratioValue == physics::RatioValue(0.))
+    {
+      backSide.center = pt;
+    }
+    else if (ratioValue > physics::RatioValue(0.))
+    {
+      backSide.left.push_back(pt);
+    }
+    else
+    {
+      backSide.right.push_back(pt);
+    }
+  }
+
+  //-------------
+  // front
+  //-------------
+  for (auto ratioValue = physics::RatioValue(-1.0); (ratioValue <= physics::RatioValue(1.0)) && result;
+       ratioValue += physics::RatioValue(0.1))
+  {
+    auto accel = vehicleState.dynamics.alphaLon.accelMax;
+    TrajectoryPoint pt;
+    result = getResponseTimeTrajectoryPoint(vehicleState, accel, ratioValue, pt);
+    if (ratioValue == physics::RatioValue(0.))
+    {
+      frontSide.center = pt;
+    }
+    else if (ratioValue > physics::RatioValue(0.))
+    {
+      frontSide.left.push_back(pt);
+    }
+    else
+    {
+      frontSide.right.push_back(pt);
+    }
+  }
+
+  return result;
+}
+
+bool TrajectoryPedestrian::getResponseTimeTrajectoryPoint(situation::VehicleState const &vehicleState,
+                                                       ad::physics::Acceleration const &aUntilResponseTime,
+                                                       ad::physics::RatioValue const &angleChangeRatio,
+                                                       TrajectoryPoint &resultTrajectoryPoint) const
+{
+  auto result = true;
   auto startingAngle = vehicleState.objectState.yaw - ad::physics::cPI_2;
   auto startingPoint = toPoint(vehicleState.objectState.centerPoint);
   ad::physics::Speed speed;
   ad::physics::Distance maxDistance;
-  situation::calculateSpeedAndDistanceOffset(duration,
+  situation::calculateSpeedAndDistanceOffset(vehicleState.dynamics.responseTime,
                                              vehicleState.objectState.speed,
                                              vehicleState.dynamics.responseTime,
                                              vehicleState.dynamics.maxSpeedOnAcceleration,
                                              aUntilResponseTime,
-                                             aAfterResponseTime,
+                                             aUntilResponseTime,
                                              speed,
                                              maxDistance);
 
@@ -136,142 +514,45 @@ TrajectoryPoint TrajectoryPedestrian::getFinalTrajectoryPoint(situation::Vehicle
   Line linePts;
   boost::geometry::append(linePts, startingPoint);
 #endif
-  Point finalPoint;
-  ad::physics::Angle finalAngle = vehicleState.objectState.yaw;
 
+  TrajectoryPoint currentPoint(vehicleState);
+  
+  Point pointAfterResponseTime;
+  auto angleChange = physics::Angle(0.);
   if (static_cast<double>(std::fabs(angleChangeRatio))
       > vehicleState.dynamics.unstructuredSettings.pedestrianTurningRadius / maxRadius)
   {
+    //move on circle
     auto radius = vehicleState.dynamics.unstructuredSettings.pedestrianTurningRadius / angleChangeRatio;
 
     auto circleOrigin = getCircleOrigin(startingPoint, radius, startingAngle);
     ad::physics::Distance distanceUntilReponseTime;
 
     situation::calculateAcceleratedLimitedMovement(vehicleState.objectState.speed,
-                                                   vehicleState.dynamics.maxSpeedOnAcceleration,
-                                                   aUntilResponseTime,
-                                                   vehicleState.dynamics.responseTime,
-                                                   speed,
-                                                   distanceUntilReponseTime);
+                                                    vehicleState.dynamics.maxSpeedOnAcceleration,
+                                                    aUntilResponseTime,
+                                                    vehicleState.dynamics.responseTime,
+                                                    speed,
+                                                    distanceUntilReponseTime);
 
-    auto angleChange = ad::physics::Angle(distanceUntilReponseTime / radius);
+    angleChange = ad::physics::Angle(distanceUntilReponseTime / radius);
 
-    auto pointAfterResponseTime = getPointOnCircle(circleOrigin, radius, startingAngle + angleChange);
-#if DEBUG_DRAWING
-    boost::geometry::append(linePts, pointAfterResponseTime);
-#endif
-
-    auto remainingDistance = maxDistance - distanceUntilReponseTime;
-    ad::physics::Angle const deltaAngle = ad::physics::cPI_2 - angleChange - startingAngle;
-    // after response time continue on a straight line
-    finalPoint = pointAfterResponseTime
-      + toPoint(-std::cos(deltaAngle) * remainingDistance, std::sin(deltaAngle) * remainingDistance);
-#if DEBUG_DRAWING
-    boost::geometry::append(linePts, finalPoint);
-#endif
-    finalAngle = vehicleState.objectState.yaw + angleChange;
+    pointAfterResponseTime = getPointOnCircle(circleOrigin, radius, startingAngle + angleChange);
   }
   else
   {
     // straight line
-    finalPoint = startingPoint + toPoint(-std::sin(startingAngle) * maxDistance, std::cos(startingAngle) * maxDistance);
-#if DEBUG_DRAWING
-    boost::geometry::append(linePts, startingPoint);
-    boost::geometry::append(linePts, finalPoint);
-#endif
+    pointAfterResponseTime = startingPoint + toPoint(-std::sin(startingAngle) * maxDistance, std::cos(startingAngle) * maxDistance);
   }
-
 #if DEBUG_DRAWING
-  DEBUG_DRAWING_LINE(linePts, "orange", debugNamespace + "trajectory");
-#else
-  (void)debugNamespace;
+  boost::geometry::append(linePts, pointAfterResponseTime);
 #endif
 
-  return TrajectoryPoint(finalPoint, finalAngle, speed, physics::AngularVelocity(0.));
-}
-
-Polygon TrajectoryPedestrian::calculateFrontWithDimension(Trajectory const &trajectory,
-                                                          ad::physics::Dimension2D const &vehicleDimension)
-{
-  // create lines through lefts, rights, centers
-  Polygon frontPts;
-  for (auto const &pt : trajectory)
-  {
-    boost::geometry::append(frontPts, getVehicleCorner(pt, vehicleDimension, VehicleCorner::frontLeft));
-    boost::geometry::append(frontPts, getVehicleCorner(pt, vehicleDimension, VehicleCorner::frontRight));
-  }
-  Polygon frontPolygon;
-  boost::geometry::convex_hull(frontPts, frontPolygon);
-  return frontPolygon;
-}
-
-Polygon TrajectoryPedestrian::calculateBackWithDimension(situation::VehicleState const &vehicleState,
-                                                         ad::physics::Duration const &duration,
-                                                         ad::physics::Acceleration const &aAfterResponseTime)
-{
-  Polygon backPolygon;
-  // the polygon contains of the vehicle corners for max brake and aAfterResponseTime with max left and max right
-
-  auto accelLeft = getFinalTrajectoryPoint(vehicleState,
-                                           duration,
-                                           vehicleState.dynamics.alphaLon.accelMax,
-                                           aAfterResponseTime,
-                                           ad::physics::RatioValue(-1.0),
-                                           std::to_string(aAfterResponseTime) + "_back_accelLeft_");
-
-  boost::geometry::append(backPolygon,
-                          getVehicleCorner(accelLeft, vehicleState.objectState.dimension, VehicleCorner::frontRight));
+  resultTrajectoryPoint = TrajectoryPoint(pointAfterResponseTime, vehicleState.objectState.yaw + angleChange, speed, physics::AngularVelocity(0.));
 #if DEBUG_DRAWING
-  DEBUG_DRAWING_POLYGON(TrafficParticipantLocation(accelLeft, vehicleState).toPolygon(),
-                        "yellow",
-                        std::to_string(aAfterResponseTime) + "_back_accelLeft_vehicle_final_position_right");
+  DEBUG_DRAWING_LINE(linePts, "orange", std::to_string(aUntilResponseTime) + "_" + std::to_string(angleChangeRatio) + "_trajectory");
 #endif
-
-  auto accelRight = getFinalTrajectoryPoint(vehicleState,
-                                            duration,
-                                            vehicleState.dynamics.alphaLon.accelMax,
-                                            aAfterResponseTime,
-                                            ad::physics::RatioValue(1.0),
-                                            std::to_string(aAfterResponseTime) + "_back_accelRight_");
-
-  boost::geometry::append(backPolygon,
-                          getVehicleCorner(accelRight, vehicleState.objectState.dimension, VehicleCorner::frontLeft));
-#if DEBUG_DRAWING
-  DEBUG_DRAWING_POLYGON(TrafficParticipantLocation(accelRight, vehicleState).toPolygon(),
-                        "yellow",
-                        std::to_string(aAfterResponseTime) + "_back_accelRight_vehicle_final_position_right");
-#endif
-  auto brakeMaxRight = getFinalTrajectoryPoint(vehicleState,
-                                               duration,
-                                               vehicleState.dynamics.alphaLon.brakeMax,
-                                               vehicleState.dynamics.alphaLon.brakeMax,
-                                               ad::physics::RatioValue(1.0),
-                                               std::to_string(aAfterResponseTime) + "_back_brakeMaxRight_");
-
-  boost::geometry::append(backPolygon,
-                          getVehicleCorner(brakeMaxRight, vehicleState.objectState.dimension, VehicleCorner::backLeft));
-#if DEBUG_DRAWING
-  DEBUG_DRAWING_POLYGON(TrafficParticipantLocation(brakeMaxRight, vehicleState).toPolygon(),
-                        "yellow",
-                        std::to_string(aAfterResponseTime) + "_back_brakeMaxRight_vehicle_final_position_right");
-#endif
-  auto brakeMaxLeft = getFinalTrajectoryPoint(vehicleState,
-                                              duration,
-                                              vehicleState.dynamics.alphaLon.brakeMax,
-                                              vehicleState.dynamics.alphaLon.brakeMax,
-                                              ad::physics::RatioValue(-1.0),
-                                              std::to_string(aAfterResponseTime) + "_back_brakeMaxLeft_");
-
-  boost::geometry::append(backPolygon,
-                          getVehicleCorner(brakeMaxLeft, vehicleState.objectState.dimension, VehicleCorner::backRight));
-#if DEBUG_DRAWING
-  DEBUG_DRAWING_POLYGON(TrafficParticipantLocation(brakeMaxLeft, vehicleState).toPolygon(),
-                        "yellow",
-                        std::to_string(aAfterResponseTime) + "_back_brakeMaxLeft_vehicle_final_position_left");
-#endif
-
-  boost::geometry::append(backPolygon, backPolygon.outer().front());
-  return backPolygon;
+  return result;
 }
 
 } // namespace unstructured

--- a/ad_rss/impl/src/unstructured/TrajectoryPedestrian.hpp
+++ b/ad_rss/impl/src/unstructured/TrajectoryPedestrian.hpp
@@ -64,61 +64,101 @@ public:
 
 private:
   /**
-   * @brief Create a trajectory set
+   * @brief calculate step polygon
    *
-   * @param[in]  vehicleState       current state of the vehicle
-   * @param[in]  duration           duration to follow the trajectory
-   * @param[in]  aAfterResponseTime acceleration to apply after response time
-   * @param[out] trajectorySet      resulting trajectory set
+   * @param[in] step              the front points
+   * @param[in] vehicleDimension   vehicle dimension
+   * @param[out] resultPolygon     polygon describing the front
    *
    * @returns false if a failure occurred during calculations, true otherwise
    */
-  bool createTrajectorySet(situation::VehicleState const &vehicleState,
-                           ad::physics::Duration const &duration,
-                           ad::physics::Acceleration const &aAfterResponseTime,
-                           Polygon &trajectorySet);
+  bool calculateStepPolygon(situation::VehicleState const &vehicleState,
+                                             physics::Distance const &distance,
+                                             TrajectorySetStep const &step,
+                                             std::string const &debugNamespace,
+                                                          Polygon &polygon) const;
+             
+  /**
+   * @brief Calculate all trajectory points at response time
+   *
+   * @param[in]  vehicleState current state of the vehicle
+   * @param[out] frontSide the trajectory points defining the front
+   * @param[out] backSide the trajectory points defining the back
+   *
+   * @returns false if a failure occurred during calculations, true otherwise
+   */
+  bool getResponseTimeTrajectoryPoints(situation::VehicleState const &vehicleState,
+                                       TrajectorySetStep &frontSide,
+                                       TrajectorySetStep &backSide) const;
 
   /**
-   * @brief Get the final point of a trajectory
+   * @brief Calculate a single trajectory point at response time
    *
-   * @param[in] vehicleState       current state of the vehicle
-   * @param[in] duration           duration to follow the trajectory
-   * @param[in] aUntilResponseTime acceleration to apply until response time
-   * @param[in] aAfterResponseTime acceleration to apply after response time
-   * @param[in] yawRateRatio       change of yaw over time
-   * @param[in] debugNamespace     namespace to use for debug drawings
+   * @param[in]  vehicleState          current state of the vehicle
+   * @param[in]  aUntilResponseTime    acceleration until response time
+   * @param[in]  yawRateChangeRatio    yaw rate change ratio
+   * @param[out] resultTrajectoryPoint resulting trajectory point
    *
-   * @returns final trajectory point
+   * @returns false if a failure occurred during calculations, true otherwise
    */
-  TrajectoryPoint getFinalTrajectoryPoint(situation::VehicleState const &vehicleState,
-                                          ad::physics::Duration const &duration,
-                                          ad::physics::Acceleration const &aUntilResponseTime,
-                                          ad::physics::Acceleration const &aAfterResponseTime,
-                                          ad::physics::RatioValue const &yawRateRatio,
-                                          std::string const &debugNamespace) const;
-
+  bool getResponseTimeTrajectoryPoint(situation::VehicleState const &vehicleState,
+                                      ad::physics::Acceleration const &aUntilResponseTime,
+                                      ad::physics::RatioValue const &yawRateChangeRatio,
+                                      TrajectoryPoint &resultTrajectoryPoint) const;
+              
   /**
-   * @brief calculate front of a trajectory set
+   * @brief Calculate the final point after response time
    *
-   * @param[in] vehicleState       current state of the vehicle
-   * @param[in] vehicleDimension   vehicle dimension
+   * @param[in]  pointAfterResponseTime point at response time
+   * @param[in]  distance               distance of the final point
    *
-   * @returns polygon describing the front
+   * @returns final point 
    */
-  Polygon calculateFrontWithDimension(Trajectory const &trajectory, ad::physics::Dimension2D const &vehicleDimension);
-
+  TrajectoryPoint calculateFinalPoint(TrajectoryPoint const &pointAfterResponseTime,
+                                                  physics::Distance const &distance) const;
+                     
   /**
-   * @brief calculate back of a trajectory set
+   * @brief Calculate a side polygon
    *
-   * @param[in] vehicleState       current state of the vehicle
-   * @param[in] vehicleDimension   vehicle dimension
-   * @param[in] aAfterResponseTime acceleration to apply after response time
+   * @param[in]  vehicleState          current state of the vehicle
+   * @param[in]  finalPointMin         minimal point
+   * @param[in]  finalPointMax         maximum point
    *
-   * @returns polygon describing the back
-   */
-  Polygon calculateBackWithDimension(situation::VehicleState const &vehicleState,
-                                     ad::physics::Duration const &duration,
-                                     ad::physics::Acceleration const &aAfterResponseTime);
+   * @returns polygon describing the side
+   */                                
+  Polygon calculateSidePolygon(situation::VehicleState const &vehicleState,
+                                              TrajectoryPoint const &finalPointMin,
+                                              TrajectoryPoint const &finalPointMax) const;
+                             
+  /**
+   * @brief Calculate the trajectory sets if pedestrian stands still
+   *
+   * @param[in]  vehicleState           current state of the pedestrian
+   * @param[in]  timeToStop             time to step with stated braking pattern
+   * @param[out] brakePolygon           the trajectory set for braking behavior
+   * @param[out] continueForwardPolygon the trajectory set for continue-forward behavior
+   *
+   * @returns false if a failure occurred during calculations, true otherwise
+   */                                 
+  bool calculateTrajectorySetsStandingStill(situation::VehicleState const &vehicleState,
+  physics::Duration const &timeToStop,
+                                                    Polygon &brakePolygon,
+                                                    Polygon &continueForwardPolygon) const;
+                     
+  /**
+   * @brief Calculate the trajectory sets if pedestrian is currently moving
+   *
+   * @param[in]  vehicleState           current state of the pedestrian
+   * @param[in]  timeToStop             time to step with stated braking pattern
+   * @param[out] brakePolygon           the trajectory set for braking behavior
+   * @param[out] continueForwardPolygon the trajectory set for continue-forward behavior
+   *
+   * @returns false if a failure occurred during calculations, true otherwise
+   */  
+  bool calculateTrajectorySetsMoving(situation::VehicleState const &vehicleState,
+  physics::Duration const &timeToStop,
+                                                    Polygon &brakePolygon,
+                                                    Polygon &continueForwardPolygon) const;
 };
 
 } // namespace unstructured

--- a/ad_rss/impl/src/unstructured/TrajectoryPedestrian.hpp
+++ b/ad_rss/impl/src/unstructured/TrajectoryPedestrian.hpp
@@ -73,11 +73,11 @@ private:
    * @returns false if a failure occurred during calculations, true otherwise
    */
   bool calculateStepPolygon(situation::VehicleState const &vehicleState,
-                                             physics::Distance const &distance,
-                                             TrajectorySetStep const &step,
-                                             std::string const &debugNamespace,
-                                                          Polygon &polygon) const;
-             
+                            physics::Distance const &distance,
+                            TrajectorySetStep const &step,
+                            std::string const &debugNamespace,
+                            Polygon &polygon) const;
+
   /**
    * @brief Calculate all trajectory points at response time
    *
@@ -105,18 +105,18 @@ private:
                                       ad::physics::Acceleration const &aUntilResponseTime,
                                       ad::physics::RatioValue const &yawRateChangeRatio,
                                       TrajectoryPoint &resultTrajectoryPoint) const;
-              
+
   /**
    * @brief Calculate the final point after response time
    *
    * @param[in]  pointAfterResponseTime point at response time
    * @param[in]  distance               distance of the final point
    *
-   * @returns final point 
+   * @returns final point
    */
   TrajectoryPoint calculateFinalPoint(TrajectoryPoint const &pointAfterResponseTime,
-                                                  physics::Distance const &distance) const;
-                     
+                                      physics::Distance const &distance) const;
+
   /**
    * @brief Calculate a side polygon
    *
@@ -125,11 +125,11 @@ private:
    * @param[in]  finalPointMax         maximum point
    *
    * @returns polygon describing the side
-   */                                
+   */
   Polygon calculateSidePolygon(situation::VehicleState const &vehicleState,
-                                              TrajectoryPoint const &finalPointMin,
-                                              TrajectoryPoint const &finalPointMax) const;
-                             
+                               TrajectoryPoint const &finalPointMin,
+                               TrajectoryPoint const &finalPointMax) const;
+
   /**
    * @brief Calculate the trajectory sets if pedestrian stands still
    *
@@ -139,12 +139,12 @@ private:
    * @param[out] continueForwardPolygon the trajectory set for continue-forward behavior
    *
    * @returns false if a failure occurred during calculations, true otherwise
-   */                                 
+   */
   bool calculateTrajectorySetsStandingStill(situation::VehicleState const &vehicleState,
-  physics::Duration const &timeToStop,
-                                                    Polygon &brakePolygon,
-                                                    Polygon &continueForwardPolygon) const;
-                     
+                                            physics::Duration const &timeToStop,
+                                            Polygon &brakePolygon,
+                                            Polygon &continueForwardPolygon) const;
+
   /**
    * @brief Calculate the trajectory sets if pedestrian is currently moving
    *
@@ -154,11 +154,11 @@ private:
    * @param[out] continueForwardPolygon the trajectory set for continue-forward behavior
    *
    * @returns false if a failure occurred during calculations, true otherwise
-   */  
+   */
   bool calculateTrajectorySetsMoving(situation::VehicleState const &vehicleState,
-  physics::Duration const &timeToStop,
-                                                    Polygon &brakePolygon,
-                                                    Polygon &continueForwardPolygon) const;
+                                     physics::Duration const &timeToStop,
+                                     Polygon &brakePolygon,
+                                     Polygon &continueForwardPolygon) const;
 };
 
 } // namespace unstructured

--- a/ad_rss/impl/src/unstructured/TrajectoryVehicle.cpp
+++ b/ad_rss/impl/src/unstructured/TrajectoryVehicle.cpp
@@ -89,13 +89,16 @@ bool TrajectoryVehicle::calculateTrajectorySets(situation::VehicleState const &v
                                       continueForwardPolygon);
     if (!result)
     {
-      spdlog::debug("TrajectoryVehicle::calculateTrajectorySets>> calculateContinueForward() failed.");
+      //fallback
+      spdlog::warn("TrajectoryVehicle::calculateTrajectorySets>> calculateContinueForward() failed. Use brakePolygon as fallback.");
+      result = true;
+      continueForwardPolygon = brakePolygon; 
     }
   }
 #if DEBUG_DRAWING
   DEBUG_DRAWING_POLYGON(brakePolygon, "red", "brake");
   DEBUG_DRAWING_POLYGON(continueForwardPolygon, "green", "continueForward");
-  spdlog::warn("DRAW DONE");
+  spdlog::trace("DRAW DONE");
 #endif
   return result;
 }
@@ -118,50 +121,59 @@ bool TrajectoryVehicle::getResponseTimeTrajectoryPoints(situation::VehicleState 
   //-------------
   // back
   //-------------
-  auto ratioDiffBack = physics::RatioValue(
-    2.0 / (2.0 * vehicleState.dynamics.unstructuredSettings.vehicleBackIntermediateRatioSteps + 2.0));
-  for (auto ratioValue = physics::RatioValue(-1.0); (ratioValue <= physics::RatioValue(1.0)) && result;
-       ratioValue += ratioDiffBack)
   {
+    auto ratioDiffBack = physics::RatioValue(
+      2.0 / (2.0 * vehicleState.dynamics.unstructuredSettings.vehicleBackIntermediateRatioSteps + 2.0));
     auto accel = vehicleState.dynamics.alphaLon.brakeMax;
-    TrajectoryPoint pt;
-    result = getResponseTimeTrajectoryPoint(vehicleState, accel, ratioValue, pt);
-    if (ratioValue == physics::RatioValue(0.))
+    physics::Duration timeInMovementUntilResponseTime;
+    result = getTimeInMovementUntilResponse(vehicleState, accel, timeInMovementUntilResponseTime);
+    for (auto ratioValue = physics::RatioValue(-1.0); (ratioValue <= physics::RatioValue(1.0)) && result;
+        ratioValue += ratioDiffBack)
     {
-      backSide.center = pt;
-    }
-    else if (ratioValue > physics::RatioValue(0.))
-    {
-      backSide.left.push_back(pt);
-    }
-    else
-    {
-      backSide.right.push_back(pt);
+      TrajectoryPoint pt;
+      result = getResponseTimeTrajectoryPoint(vehicleState, timeInMovementUntilResponseTime, accel, ratioValue, pt);
+      if (ratioValue == physics::RatioValue(0.))
+      {
+        backSide.center = pt;
+      }
+      else if (ratioValue > physics::RatioValue(0.))
+      {
+        backSide.left.push_back(pt);
+      }
+      else
+      {
+        backSide.right.push_back(pt);
+      }
     }
   }
 
   //-------------
   // front
   //-------------
-  auto ratioDiffFront = physics::RatioValue(
-    2.0 / (2.0 * vehicleState.dynamics.unstructuredSettings.vehicleFrontIntermediateRatioSteps + 2.0));
-  for (auto ratioValue = physics::RatioValue(-1.0); (ratioValue <= physics::RatioValue(1.0)) && result;
-       ratioValue += ratioDiffFront)
   {
+    auto ratioDiffFront = physics::RatioValue(
+      2.0 / (2.0 * vehicleState.dynamics.unstructuredSettings.vehicleFrontIntermediateRatioSteps + 2.0));
+    
     auto accel = vehicleState.dynamics.alphaLon.accelMax;
-    TrajectoryPoint pt;
-    result = getResponseTimeTrajectoryPoint(vehicleState, accel, ratioValue, pt);
-    if (ratioValue == physics::RatioValue(0.))
+    physics::Duration timeInMovementUntilResponseTime;
+    result = getTimeInMovementUntilResponse(vehicleState, accel, timeInMovementUntilResponseTime);
+    for (auto ratioValue = physics::RatioValue(-1.0); (ratioValue <= physics::RatioValue(1.0)) && result;
+        ratioValue += ratioDiffFront)
     {
-      frontSide.center = pt;
-    }
-    else if (ratioValue > physics::RatioValue(0.))
-    {
-      frontSide.left.push_back(pt);
-    }
-    else
-    {
-      frontSide.right.push_back(pt);
+      TrajectoryPoint pt;
+      result = getResponseTimeTrajectoryPoint(vehicleState, timeInMovementUntilResponseTime, accel, ratioValue, pt);
+      if (ratioValue == physics::RatioValue(0.))
+      {
+        frontSide.center = pt;
+      }
+      else if (ratioValue > physics::RatioValue(0.))
+      {
+        frontSide.left.push_back(pt);
+      }
+      else
+      {
+        frontSide.right.push_back(pt);
+      }
     }
   }
 
@@ -177,32 +189,31 @@ bool TrajectoryVehicle::getResponseTimeTrajectoryPoints(situation::VehicleState 
     TrajectoryPoint right;
     TrajectoryPoint left;
     TrajectoryPoint center;
-    result = getResponseTimeTrajectoryPoint(vehicleState, accel, physics::RatioValue(-1.0), right);
+    physics::Duration timeInMovementUntilResponseTime;
+    result = getTimeInMovementUntilResponse(vehicleState, accel, timeInMovementUntilResponseTime);
     if (result)
     {
-      result = getResponseTimeTrajectoryPoint(vehicleState, accel, physics::RatioValue(1.0), left);
+      result = getResponseTimeTrajectoryPoint(vehicleState, timeInMovementUntilResponseTime, accel, physics::RatioValue(-1.0), right);
     }
     if (result)
     {
-      result = getResponseTimeTrajectoryPoint(vehicleState, accel, physics::RatioValue(0.0), center);
+      result = getResponseTimeTrajectoryPoint(vehicleState, timeInMovementUntilResponseTime, accel, physics::RatioValue(1.0), left);
+    }
+    if (result)
+    {
+      result = getResponseTimeTrajectoryPoint(vehicleState, timeInMovementUntilResponseTime, accel, physics::RatioValue(0.0), center);
     }
     trajectorySetSteps.push_back(TrajectorySetStep(left, right, center));
   }
   return result;
 }
 
-bool TrajectoryVehicle::getResponseTimeTrajectoryPoint(situation::VehicleState const &vehicleState,
+bool TrajectoryVehicle::getTimeInMovementUntilResponse(situation::VehicleState const &vehicleState,
                                                        ad::physics::Acceleration const &aUntilResponseTime,
-                                                       ad::physics::RatioValue const &yawRateChangeRatio,
-                                                       TrajectoryPoint &resultTrajectoryPoint) const
+                                                       ad::physics::Duration &timeInMovementUntilResponseTime) const
 {
   auto result = true;
-  TrajectoryPoint currentPoint(vehicleState);
-
-  auto currentTime = ad::physics::Duration(0.0);
-
-  ad::physics::Duration timeInMovementUntilResponseTime
-    = vehicleState.dynamics.responseTime; // until this time, the yaw rate changes
+  timeInMovementUntilResponseTime = vehicleState.dynamics.responseTime; // until this time, the yaw rate changes
   if (aUntilResponseTime < physics::Acceleration(0.))
   {
     if (vehicleState.objectState.speed == physics::Speed(0.))
@@ -228,6 +239,19 @@ bool TrajectoryVehicle::getResponseTimeTrajectoryPoint(situation::VehicleState c
       timeInMovementUntilResponseTime = std::min(vehicleState.dynamics.responseTime, timeInMovementUntilResponseTime);
     }
   }
+  return result;
+}
+
+bool TrajectoryVehicle::getResponseTimeTrajectoryPoint(situation::VehicleState const &vehicleState,
+                                                       ad::physics::Duration const &timeInMovementUntilResponseTime,
+                                                       ad::physics::Acceleration const &aUntilResponseTime,
+                                                       ad::physics::RatioValue const &yawRateChangeRatio,
+                                                       TrajectoryPoint &resultTrajectoryPoint) const
+{
+  auto result = true;
+  TrajectoryPoint currentPoint(vehicleState);
+
+  auto currentTime = ad::physics::Duration(0.0);
 
   while ((currentTime < vehicleState.dynamics.responseTime) && result)
   {
@@ -741,34 +765,6 @@ bool TrajectoryVehicle::calculateEstimationBetweenSteps(
     }
   }
   return result;
-}
-
-bool TrajectoryVehicle::combinePolygon(Polygon const &a, Polygon const &b, Polygon &result) const
-{
-  if (a.outer().empty() && !b.outer().empty())
-  {
-    result = b;
-  }
-  else if (!a.outer().empty() && b.outer().empty())
-  {
-    result = a;
-  }
-  else
-  {
-    std::vector<Polygon> unionPolygons;
-    boost::geometry::union_(a.outer(), b.outer(), unionPolygons);
-    if (unionPolygons.size() != 1)
-    {
-      spdlog::debug("Could not calculate combined polygon. Expected 1 polygon after union, found {}",
-                    unionPolygons.size());
-      return false;
-    }
-    else
-    {
-      result = std::move(unionPolygons[0]);
-    }
-  }
-  return true;
 }
 
 } // namespace unstructured

--- a/ad_rss/impl/src/unstructured/TrajectoryVehicle.cpp
+++ b/ad_rss/impl/src/unstructured/TrajectoryVehicle.cpp
@@ -89,10 +89,11 @@ bool TrajectoryVehicle::calculateTrajectorySets(situation::VehicleState const &v
                                       continueForwardPolygon);
     if (!result)
     {
-      //fallback
-      spdlog::warn("TrajectoryVehicle::calculateTrajectorySets>> calculateContinueForward() failed. Use brakePolygon as fallback.");
+      // fallback
+      spdlog::warn("TrajectoryVehicle::calculateTrajectorySets>> calculateContinueForward() failed. Use brakePolygon "
+                   "as fallback.");
       result = true;
-      continueForwardPolygon = brakePolygon; 
+      continueForwardPolygon = brakePolygon;
     }
   }
 #if DEBUG_DRAWING
@@ -128,7 +129,7 @@ bool TrajectoryVehicle::getResponseTimeTrajectoryPoints(situation::VehicleState 
     physics::Duration timeInMovementUntilResponseTime;
     result = getTimeInMovementUntilResponse(vehicleState, accel, timeInMovementUntilResponseTime);
     for (auto ratioValue = physics::RatioValue(-1.0); (ratioValue <= physics::RatioValue(1.0)) && result;
-        ratioValue += ratioDiffBack)
+         ratioValue += ratioDiffBack)
     {
       TrajectoryPoint pt;
       result = getResponseTimeTrajectoryPoint(vehicleState, timeInMovementUntilResponseTime, accel, ratioValue, pt);
@@ -153,12 +154,12 @@ bool TrajectoryVehicle::getResponseTimeTrajectoryPoints(situation::VehicleState 
   {
     auto ratioDiffFront = physics::RatioValue(
       2.0 / (2.0 * vehicleState.dynamics.unstructuredSettings.vehicleFrontIntermediateRatioSteps + 2.0));
-    
+
     auto accel = vehicleState.dynamics.alphaLon.accelMax;
     physics::Duration timeInMovementUntilResponseTime;
     result = getTimeInMovementUntilResponse(vehicleState, accel, timeInMovementUntilResponseTime);
     for (auto ratioValue = physics::RatioValue(-1.0); (ratioValue <= physics::RatioValue(1.0)) && result;
-        ratioValue += ratioDiffFront)
+         ratioValue += ratioDiffFront)
     {
       TrajectoryPoint pt;
       result = getResponseTimeTrajectoryPoint(vehicleState, timeInMovementUntilResponseTime, accel, ratioValue, pt);
@@ -193,15 +194,18 @@ bool TrajectoryVehicle::getResponseTimeTrajectoryPoints(situation::VehicleState 
     result = getTimeInMovementUntilResponse(vehicleState, accel, timeInMovementUntilResponseTime);
     if (result)
     {
-      result = getResponseTimeTrajectoryPoint(vehicleState, timeInMovementUntilResponseTime, accel, physics::RatioValue(-1.0), right);
+      result = getResponseTimeTrajectoryPoint(
+        vehicleState, timeInMovementUntilResponseTime, accel, physics::RatioValue(-1.0), right);
     }
     if (result)
     {
-      result = getResponseTimeTrajectoryPoint(vehicleState, timeInMovementUntilResponseTime, accel, physics::RatioValue(1.0), left);
+      result = getResponseTimeTrajectoryPoint(
+        vehicleState, timeInMovementUntilResponseTime, accel, physics::RatioValue(1.0), left);
     }
     if (result)
     {
-      result = getResponseTimeTrajectoryPoint(vehicleState, timeInMovementUntilResponseTime, accel, physics::RatioValue(0.0), center);
+      result = getResponseTimeTrajectoryPoint(
+        vehicleState, timeInMovementUntilResponseTime, accel, physics::RatioValue(0.0), center);
     }
     trajectorySetSteps.push_back(TrajectorySetStep(left, right, center));
   }

--- a/ad_rss/impl/src/unstructured/TrajectoryVehicle.hpp
+++ b/ad_rss/impl/src/unstructured/TrajectoryVehicle.hpp
@@ -38,7 +38,6 @@ namespace unstructured {
 class TrajectoryVehicle
 {
 public:
-
   struct TrajectorySetStepVehicleLocation
   {
     TrafficParticipantLocation left;
@@ -137,9 +136,9 @@ private:
    *
    * @returns false if a failure occurred during calculations, true otherwise
    */
-bool getTimeInMovementUntilResponse(situation::VehicleState const &vehicleState,
-                                                       ad::physics::Acceleration const &aUntilResponseTime,
-                                                       ad::physics::Duration &timeInMovementUntilResponseTime) const;
+  bool getTimeInMovementUntilResponse(situation::VehicleState const &vehicleState,
+                                      ad::physics::Acceleration const &aUntilResponseTime,
+                                      ad::physics::Duration &timeInMovementUntilResponseTime) const;
 
   /**
    * @brief Calculate the brake trajectory set

--- a/ad_rss/impl/src/unstructured/TrajectoryVehicle.hpp
+++ b/ad_rss/impl/src/unstructured/TrajectoryVehicle.hpp
@@ -38,22 +38,6 @@ namespace unstructured {
 class TrajectoryVehicle
 {
 public:
-  struct TrajectorySetStep
-  {
-    TrajectorySetStep()
-    {
-    }
-
-    TrajectorySetStep(TrajectoryPoint const &inLeft, TrajectoryPoint const &inRight, TrajectoryPoint const &inCenter)
-      : center(inCenter)
-    {
-      left.push_back(inLeft);
-      right.push_back(inRight);
-    }
-    std::vector<TrajectoryPoint> left;  // with positive yaw rate ratio
-    std::vector<TrajectoryPoint> right; // with negative yaw rate ratio
-    TrajectoryPoint center;
-  };
 
   struct TrajectorySetStepVehicleLocation
   {
@@ -114,6 +98,7 @@ private:
    * @brief Calculate a single trajectory point at response time
    *
    * @param[in]  vehicleState          current state of the vehicle
+   * @param[in]  timeInMovementUntilResponseTime time in movement until response time
    * @param[in]  aUntilResponseTime    acceleration until response time
    * @param[in]  yawRateChangeRatio    yaw rate change ratio
    * @param[out] resultTrajectoryPoint resulting trajectory point
@@ -121,6 +106,7 @@ private:
    * @returns false if a failure occurred during calculations, true otherwise
    */
   bool getResponseTimeTrajectoryPoint(situation::VehicleState const &vehicleState,
+                                      ad::physics::Duration const &timeInMovementUntilResponseTime,
                                       ad::physics::Acceleration const &aUntilResponseTime,
                                       ad::physics::RatioValue const &yawRateChangeRatio,
                                       TrajectoryPoint &resultTrajectoryPoint) const;
@@ -141,6 +127,19 @@ private:
                                     physics::Duration const &duration,
                                     ::ad::rss::world::RssDynamics const &dynamics,
                                     bool afterResponseTime) const;
+
+  /**
+   * @brief Calculate a time in movement until response time
+   *
+   * @param[in]  vehicleState                      current state of the vehicle
+   * @param[in]  aUntilResponseTime          acceleration to use
+   * @param[out]  timeInMovementUntilResponseTime   resulting time in movement
+   *
+   * @returns false if a failure occurred during calculations, true otherwise
+   */
+bool getTimeInMovementUntilResponse(situation::VehicleState const &vehicleState,
+                                                       ad::physics::Acceleration const &aUntilResponseTime,
+                                                       ad::physics::Duration &timeInMovementUntilResponseTime) const;
 
   /**
    * @brief Calculate the brake trajectory set
@@ -183,17 +182,6 @@ private:
                                 Polygon const &brakePolygon,
                                 TrajectorySetStepVehicleLocation const &brakeMinStepVehicleLocation,
                                 Polygon &resultPolygon) const;
-
-  /**
-   * @brief Combine two polygons
-   *
-   * @param[in]  a       polygon a
-   * @param[in]  b       polygon b
-   * @param[out] result  resulting polygon
-   *
-   * @returns false if a failure occurred during calculations, true otherwise
-   */
-  bool combinePolygon(Polygon const &a, Polygon const &b, Polygon &result) const;
 
   /**
    * @brief Calculate a trajectory set estimation between two steps

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,6 +1,9 @@
 
 ## Latest changes
 
+#### :ghost: Maintenance
+* Update unstructured trajectory set calculation for pedestrians
+
 ## Release 4.1.0
 
 #### :ghost: Maintenance

--- a/doc/ad_rss/SupportedRssFeatures.md
+++ b/doc/ad_rss/SupportedRssFeatures.md
@@ -1,6 +1,6 @@
 ## Release 4.x
 
-The release version 4.x extends the core features by unstructured scene calculation. 
+The release version 4.x extends the core features by unstructured constellation calculation. 
 
 ## Release 3.x
 

--- a/doc/ad_rss/UnstructuredConstellations.md
+++ b/doc/ad_rss/UnstructuredConstellations.md
@@ -1,12 +1,12 @@
 ## Overview
 
-Unstructured scenes implement unstructured roads (described in chapter 3.7.2 of the [RSS paper](https://arxiv.org/abs/1708.06374), definitions 19-22) and pedestrians (described in chapter 3.8).
-In contrast to the structured scenes, two dimensional trajectories with lateral and longitudinal component are calculated.
+Unstructured constellations implement unstructured roads (described in chapter 3.7.2 of the [RSS paper](https://arxiv.org/abs/1708.06374), definitions 19-22) and pedestrians (described in chapter 3.8).
+In contrast to the structured constellations, two dimensional trajectories with lateral and longitudinal component are calculated.
 
 
 ### World Modeling
 
-To allow customization, every scene within the [`ad::rss::world::WorldModel`](https://intel.github.io/ad-rss-lib/doxygen/ad_rss/structad_1_1rss_1_1world_1_1WorldModel.html) can be calculated as unstructured, depending on the `situationType`.
+To allow customization, every constellations within the [`ad::rss::world::WorldModel`](https://intel.github.io/ad-rss-lib/doxygen/ad_rss/structad_1_1rss_1_1world_1_1WorldModel.html) can be calculated as unstructured, depending on the `situationType`.
 
 ### Behavior Model/Trajectory Set Calculation
 
@@ -79,7 +79,7 @@ In the third step the final trajectory sets are calculated. To reach an acceptab
 
 ### Decision making
 
-The [RSS paper](https://arxiv.org/abs/1708.06374) definition 22 states conditions, that are relevant to calculate if a situation is dangerous and how to behave then.
+The [RSS paper](https://arxiv.org/abs/1708.06374) definition 22 states conditions, that are relevant to calculate if a constellation is dangerous and how to behave then.
 
 Depending on their values, three decisions are possible:
 
@@ -105,7 +105,7 @@ The following diagram describes the decision making.
 |:--:|
 | *Decision making* |
 
-The condition 22.1.b at the last safe point in time might lead to the behavior "Continue Forward" although the situation is dangerous. The reason is, that the conditions 22.1 define, which traffic participant has to brake and which one can continue.
+The condition 22.1.b at the last safe point in time might lead to the behavior "Continue Forward" although the constellation is dangerous. The reason is, that the conditions 22.1 define, which traffic participant has to brake and which one can continue.
 
 ### Response
 
@@ -119,7 +119,7 @@ If the result is _brake_, the longitudinal acceleration restriction is set to `a
 
 #### Driving away
 
-In certain situations the ego vehicle might be allowed to drive away from a dangerous situation using a given heading range.
+In certain situations the ego vehicle might be allowed to drive away from a dangerous constellation using a given heading range.
 
 The heading range is calculated using the position vectors of the traffic participants and the velocity vector of the ego.
 
@@ -127,7 +127,7 @@ The angle between $\tau_{ego}(t) − \tau_{other}(t)$  and $\tau'_{ego}(t)$ need
 
 $\theta$ can be specified by `UnstructuredSettings::driveAwayMaxAngle`
 
-As multiple situations might allow different ranges to drive away, the [`ad::rss::state::ProperResponse`](https://intel.github.io/ad-rss-lib/doxygen/ad_rss/structad_1_1rss_1_1state_1_1ProperResponse.html) provides a vector of `headingRanges`. Together with the steering range of the vehicle the allowed heading range can be calculated.
+As multiple constellations might allow different ranges to drive away, the [`ad::rss::state::ProperResponse`](https://intel.github.io/ad-rss-lib/doxygen/ad_rss/structad_1_1rss_1_1state_1_1ProperResponse.html) provides a vector of `headingRanges`. Together with the steering range of the vehicle the allowed heading range can be calculated.
 
 | ![](../images/unstructured_drive_away.png) |
 |:--:|

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,7 +10,7 @@ nav:
 - Background:
   - Overview: ad_rss/Overview.md
   - Design Discussions: ad_rss/HLD-KeyDesignDecisionsAndAlternatives.md
-  - Unstructured Scenes: ad_rss/UnstructuredScenes.md
+  - Unstructured Constellations: ad_rss/UnstructuredConstellations.md
   - System Integration: ad_rss/HLD-ArchitectureOverview.md
   - Safety: ad_rss/HLD-Safety.md
   - Security: ad_rss/HLD-Security.md


### PR DESCRIPTION
Update calculation of pedestrian trajectory sets + improve vehicle calculations

With certain parameters, the calculation failed. Therefore it now uses a similar approach as for vehicles.

Additional changes:
- the performance of vehicle calculations was improved by removing redundant calculations
- If there are problems with the calculation of the continueForward trajectory set for vehicles a warning
  is produced and the brake polygon is used as a fallback.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel/ad-rss-lib/84)
<!-- Reviewable:end -->
