### PR TITLE
Fix map-integration intersection scene

### DIFF
--- a/ad_rss_map_integration/impl/src/RssSceneCreation.cpp
+++ b/ad_rss_map_integration/impl/src/RssSceneCreation.cpp
@@ -157,7 +157,8 @@ bool RssSceneCreation::appendStructuredScenes(::ad::rss::map::RssSceneCreator &s
     {
       // for the analysis we are only interested in the near term route
       auto shortenedRoute = egoRouteInput;
-      ::ad::map::route::shortenRouteToDistance(shortenedRoute, std::max(predictionLength, ::ad::physics::Distance(100.)));
+      ::ad::map::route::shortenRouteToDistance(shortenedRoute,
+                                               std::max(predictionLength, ::ad::physics::Distance(100.)));
       egoPredictedRoutes.push_back(shortenedRoute);
     }
 

--- a/ad_rss_map_integration/impl/src/RssSceneCreation.cpp
+++ b/ad_rss_map_integration/impl/src/RssSceneCreation.cpp
@@ -157,7 +157,7 @@ bool RssSceneCreation::appendStructuredScenes(::ad::rss::map::RssSceneCreator &s
     {
       // for the analysis we are only interested in the near term route
       auto shortenedRoute = egoRouteInput;
-      ::ad::map::route::shortenRouteToDistance(shortenedRoute, predictionLength);
+      ::ad::map::route::shortenRouteToDistance(shortenedRoute, std::max(predictionLength, ::ad::physics::Distance(100.)));
       egoPredictedRoutes.push_back(shortenedRoute);
     }
 

--- a/ad_rss_map_integration/python/tests/interface_test.py
+++ b/ad_rss_map_integration/python/tests/interface_test.py
@@ -189,7 +189,7 @@ class AdRssMapIntegrationPythonTest(unittest.TestCase):
         longitudinal_distance = rss_situation_snapshot.situations[0].relativePosition.longitudinalDistance
 
         self.assertTrue(rss_proper_response.isSafe)
-        self.assertEqual(longitudinal_distance, ad.physics.Distance(104.411))
+        self.assertEqual(longitudinal_distance, ad.physics.Distance(104.415))
 
         self.world_model.timeIndex += 1
 

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### :ghost: Maintenance
 * Fix: Consider lateral fluctuation margin correctly.
+* Fix: ad_rss_map_integration don't shorten route too much within intersections
 * Updated ad_map_access to v2.4.5
 * Use target python version for build
 * Fix: Ensure maxSpeedOnAcceleration only limits the actual acceleration while reponse time.


### PR DESCRIPTION
Fix: ad_rss_map_integration don't shorten route too much within
intersections when incoming route starts at intersection entry while
vehicle already entered.

Change-Id: I56bf4708438f3e4b04a43b84e7b31c0adfd88bac

<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.

Checklist:

  - [ ] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly and runs
  - [ ] Code is formatted using clang-3.9 and the provided format file
  - [ ] Changelog is updated

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->

Fixes #  <!-- If fixes an issue, please add here the issue number. -->

#### Where has this been tested?

  * **Platform(s):** ...
  * **Library version:** ...

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel/ad-rss-lib/111)
<!-- Reviewable:end -->
