### PR TITLE
Removed duplicated spdlog dependency and modified building instruction

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -47,7 +47,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-          submodules: true
+          submodules: recursive
 
     - name: Install Dependencies
       run: bash .github/workflows/install_dependencies.sh
@@ -79,7 +79,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-          submodules: true
+          submodules: recursive
 
     - name: Install Dependencies
       run: bash .github/workflows/install_dependencies.sh

--- a/.github/workflows/check_documentation.yml
+++ b/.github/workflows/check_documentation.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-        submodules: true
+        submodules: recursive
 
     - name: Install Dependencies
       run: |

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v1
         with:
           fetch-depth: 1
-          submodules: true
+          submodules: recursive
       - name: Prepare PROJ
         run: |
           git clone --depth=1 -b 4.9.3 https://github.com/OSGeo/PROJ.git dependencies/PROJ

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "dependencies/spdlog"]
-	path = dependencies/spdlog
-	url = https://github.com/gabime/spdlog.git
 [submodule "dependencies/map"]
 	path = dependencies/map
 	url = https://github.com/carla-simulator/map.git

--- a/doc/BUILDING.md
+++ b/doc/BUILDING.md
@@ -61,7 +61,7 @@ Please use the link above for installation instructions.
 This repository is prepared as colcon workspace including all dependencies not provided as installable packages by the OS.
 Those dependencies are part of the __dependencies__ folder as GIT submodules. To properly fetch these, the submodules have to be updated and initialized.
 ```bash
- ad-rss-lib$>  git submodule update --init
+ ad-rss-lib$>  git submodule update --init --recursive
 ```
 Once this is done, the full set of dependencies and components can be built calling:
 ```bash

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Latest changes
 
 #### :ghost: Maintenance
+* Fix: removed duplicated spdlog dependency
 * Update map to v2.6.0
 
 ## Release 4.5.0


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.
-->
Checklist:

  - [x] Your branch is up-to-date with the `master` branch and tested with latest changes
  - [x] Extended the README / documentation, if necessary
  - [x] Code compiles correctly and runs
  - [x] Code is formatted using clang-3.9 and the provided format file
  - [x] Changelog is updated



#### Description

The `spdlog` is added to `ad-rss-lib` as dependency and it's added to `carla_simulator/map` that is also the dependency of `ad-rss-lib`.
Because of that, it's not possible to update submodules recursively.

In this PR, the `spdlog` dependency is removed from `ad-rss-lib`, so only one version remains in `carla_simulator/map`.
It allows adding the `ad-rss-lib` to other packages (especially ROS2 packages) as dependency and updating dependencies with --recursive option.

<!-- Please explain the changes you made here as detailed as possible. -->

Fixes #116

#### Where has this been tested?

  * **Platform(s):** Ubuntu 20.04
  * **Library version:**4.5.0

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel/ad-rss-lib/117)
<!-- Reviewable:end -->
