### PR TITLE
Enable Ubuntu 22.04 builds

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -75,6 +75,11 @@ jobs:
            CC: ""
            CXX: ""
            PYTHON_BINDING_VERSION: "3.8"
+         - compiler: clang10
+           EXTRA_PACKAGES: clang-10
+           CC: /usr/bin/clang-10
+           CXX: /usr/bin/clang++-10
+           PYTHON_BINDING_VERSION: "3.8"
 
     steps:
     - uses: actions/checkout@v2
@@ -94,3 +99,41 @@ jobs:
         sudo apt-get install ${EXTRA_PACKAGES}
         rm -rf log build install
         eval CC=${CC} CXX=${CXX} ${BUILDCMD}
+
+  ubuntu22job:
+    name: Ubuntu 22.04
+    runs-on: ubuntu-22.04
+
+    strategy:
+      matrix:
+       include:
+         - compiler: gcc11
+           EXTRA_PACKAGES: ""
+           CC: ""
+           CXX: ""
+           PYTHON_BINDING_VERSION: "3.10"
+         - compiler: clang14
+           EXTRA_PACKAGES: clang-14
+           CC: /usr/bin/clang-14
+           CXX: /usr/bin/clang++-14
+           PYTHON_BINDING_VERSION: "3.10"
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+          submodules: recursive
+
+    - name: Install Dependencies
+      run: bash .github/workflows/install_dependencies.sh
+
+    - name: Build and Test
+      env:
+          CC: ${{ matrix.CC }}
+          CXX: ${{ matrix.CXX }}
+          EXTRA_PACKAGES: ${{ matrix.EXTRA_PACKAGES }}
+          PYTHON_BINDING_VERSION: ${{ matrix.PYTHON_BINDING_VERSION }}
+      run: |
+        sudo apt-get install ${EXTRA_PACKAGES}
+        rm -rf log build install
+        eval CC=${CC} CXX=${CXX} ${BUILDCMD}
+

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   ubuntu18job:
     name: Ubuntu 18.04
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
@@ -28,11 +28,6 @@ jobs:
            CC: /usr/bin/gcc-8
            CXX: /usr/bin/g++-8
            PYTHON_BINDING_VERSION: "3.6 -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/python3.6"
-         - compiler: gcc9
-           EXTRA_PACKAGES: g++-9
-           CC: /usr/bin/gcc-9
-           CXX: /usr/bin/g++-9
-           PYTHON_BINDING_VERSION: "3.6 -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/python3.6"
          - compiler: clang7
            EXTRA_PACKAGES: clang-7
            CC: /usr/bin/clang-7
@@ -44,9 +39,16 @@ jobs:
            CXX: /usr/bin/clang++-8
            PYTHON_BINDING_VERSION: "3.6 -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/python3.6"
 
+    container:
+      image: ubuntu:18.04
+
     steps:
-    - uses: actions/checkout@v2
+    - name: Install base packages
+      run: apt update && apt install -y git sudo
+
+    - uses: actions/checkout@v1
       with:
+          depth: 
           submodules: recursive
 
     - name: Install Dependencies
@@ -59,9 +61,10 @@ jobs:
           EXTRA_PACKAGES: ${{ matrix.EXTRA_PACKAGES }}
           PYTHON_BINDING_VERSION: ${{ matrix.PYTHON_BINDING_VERSION }}
       run: |
-        sudo apt-get install ${EXTRA_PACKAGES}
+        sudo apt-get install -y ${EXTRA_PACKAGES}
         rm -rf log build install
         eval CC=${CC} CXX=${CXX} ${BUILDCMD}
+
 
   ubuntu20job:
     name: Ubuntu 20.04

--- a/.github/workflows/install_dependencies.sh
+++ b/.github/workflows/install_dependencies.sh
@@ -1,18 +1,27 @@
 #!/bin/bash
 
-sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-sudo apt-get update
-sudo apt-get install -y --no-install-recommends build-essential castxml cmake libboost-all-dev libgtest-dev liblapacke-dev libopenblas-dev libproj-dev libpugixml-dev libpython3-dev python python-setuptools python3 python3-pip python3-setuptools python3-wheel
+python3_pkgs="libpython3-dev python3 python3-pip python3-setuptools python3-wheel"
+python2_pkgs="libpython-dev python python-pip python-wheel python-setuptools"
+other_pkgs="build-essential castxml cmake libboost-all-dev libgtest-dev liblapacke-dev libopenblas-dev libpugixml-dev sqlite3"
 
-if [ `lsb_release -a | grep Release | grep 2*.04 | wc -l` == 1 ]; then
-  sudo apt-get install -y --no-install-recommends python-is-python3
-else
-  sudo apt-get install -y --no-install-recommends python-pip python-wheel
+sudo apt-get update
+sudo apt-get install -y lsb-core
+
+if [ `lsb_release -a | grep Release | grep 18.04 | wc -l` == 1 ]; then
+  sudo add-apt-repository ppa:ubuntu-toolchain-r/test
 fi
+
+sudo apt-get update
+sudo apt-get install -y --no-install-recommends ${other_pkgs} ${python3_pkgs}
+
 sudo pip3 install --upgrade setuptools==51.1.2
 sudo pip3 install colcon-common-extensions xmlrunner pygccxml pyplusplus
 
-if [ `lsb_release -a | grep Release | grep 20.04 | wc -l` != 1 ]; then
+if [ `lsb_release -a | grep Release | grep 18.04 | wc -l` == 1 ]; then
+  sudo apt-get install -y --no-install-recommends ${python2_pkgs}
   sudo pip2 install --upgrade setuptools==41.1.0
-  sudo pip2 install pygccxml pyplusplus xmlrunner
+  sudo pip2 install pygccxml==2.2.1 pyplusplus==1.8.4 xmlrunner
+else
+  sudo apt-get install -y --no-install-recommends "python-is-python3"
 fi
+

--- a/.github/workflows/install_dependencies.sh
+++ b/.github/workflows/install_dependencies.sh
@@ -4,7 +4,7 @@ sudo add-apt-repository ppa:ubuntu-toolchain-r/test
 sudo apt-get update
 sudo apt-get install -y --no-install-recommends build-essential castxml cmake libboost-all-dev libgtest-dev liblapacke-dev libopenblas-dev libproj-dev libpugixml-dev libpython3-dev python python-setuptools python3 python3-pip python3-setuptools python3-wheel
 
-if [ `lsb_release -a | grep Release | grep 20.04 | wc -l` == 1 ]; then
+if [ `lsb_release -a | grep Release | grep 2*.04 | wc -l` == 1 ]; then
   sudo apt-get install -y --no-install-recommends python-is-python3
 else
   sudo apt-get install -y --no-install-recommends python-pip python-wheel

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   wheels:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python_binding_version: [2.7, 3.6, 3.7, 3.8]
@@ -25,12 +25,10 @@ jobs:
         with:
           fetch-depth: 1
           submodules: recursive
-      - name: Prepare PROJ
-        run: |
-          git clone --depth=1 -b 4.9.3 https://github.com/OSGeo/PROJ.git dependencies/PROJ
       - name: Build wheels
         shell: bash
         run: |
+          apt-get update && apt-get install sqlite3 -y
           colcon build --packages-select PROJ4 --event-handlers console_direct+ --cmake-args -DCMAKE_POSITION_INDEPENDENT_CODE=ON
           source install/setup.bash
           colcon build --packages-up-to ad_rss_map_integration --meta colcon_python.meta --event-handlers console_direct+ --cmake-args -DPYTHON_BINDING_VERSION=${PYTHON_BINDING_VERSION}

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ To download the library, you may run:
 
 #### Supported systems <a name="systems"></a>
 Development systems are Ubuntu 18.04, Ubuntu 20.04 and Ubuntu 22.04
-Following compiler combinations are [tested continously](https://github.com/intel/ad-rss-lib/blob/master/.travis.yml):
+Following compiler and Python combinations are [tested continously](https://github.com/intel/ad-rss-lib/blob/master/.travis.yml):
 
 |                 | Ubuntu 18.04 | Ubuntu 20.04 | Ubuntu 22.04 |
 |:---------------:|:------------:|:------------:|:------------:|
@@ -148,6 +148,10 @@ Following compiler combinations are [tested continously](https://github.com/inte
 |  Clang 10       |              |       x      |              |
 |   GCC 11        |              |              |       x      |
 |  Clang 14       |              |              |       x      |
+|  Python 2.7     |       x      |              |              |
+|  Python 3.6     |       x      |              |              |
+|  Python 3.8     |              |       x      |              |
+|  Python 3.10    |              |              |       x      |
 
 Important: cmake is required to be at least version 3.5!
 

--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ Note: The RSS module in this library does not initiate evasive manuevers. At the
 ## Getting started <a name="started"></a>
 
 #### Installation of dependencies
-Currently, the focused operating systems are Ubuntu 18.04 and Ubuntu 20.04. Nevertheless, the library should work in a similar way for any other Linux OS.
-To install the basic dependencies for Ubuntu 18.04/20.04 execute the following command:
+Currently, the focused operating systems are Ubuntu 18.04, Ubuntu 20.04 and Ubuntu 22.04. Nevertheless, the library should work in a similar way for any other Linux OS.
+To install the basic dependencies for Ubuntu 18.04/20.04/22.04 execute the following command:
 ```bash
  user$> sudo apt-get install git build-essential cmake libboost-dev libpugixml-dev libgtest-dev libpython-dev libproj-dev
 ```
@@ -135,16 +135,19 @@ To download the library, you may run:
 ```
 
 #### Supported systems <a name="systems"></a>
-Development systems are Ubuntu 18.04 and Ubuntu 20.04.
+Development systems are Ubuntu 18.04, Ubuntu 20.04 and Ubuntu 22.04
 Following compiler combinations are [tested continously](https://github.com/intel/ad-rss-lib/blob/master/.travis.yml):
 
-|                 | Ubuntu 18.04 | Ubuntu 20.04 |
-|:---------------:|:------------:|:------------:|
-|  Clang 7        |       x      |              |
-|  Clang 8        |       x      |              |
-|   GCC 7         |       x      |              |
-|   GCC 8         |       x      |              |
-|   GCC 9         |       x      |       x      |
+|                 | Ubuntu 18.04 | Ubuntu 20.04 | Ubuntu 22.04 |
+|:---------------:|:------------:|:------------:|:------------:|
+|  Clang 7        |       x      |              |              |
+|  Clang 8        |       x      |              |              |
+|   GCC 7         |       x      |              |              |
+|   GCC 8         |       x      |              |              |
+|   GCC 9         |              |       x      |              |
+|  Clang 10       |              |       x      |              |
+|   GCC 11        |              |              |       x      |
+|  Clang 14       |              |              |       x      |
 
 Important: cmake is required to be at least version 3.5!
 

--- a/ad_rss/python/generate_python_lib.py.in
+++ b/ad_rss/python/generate_python_lib.py.in
@@ -33,7 +33,8 @@ def main():
 
     additional_replacements = {
         # RoadSegment: vector<vector>>, set name manually, tool doesn't understand correctly
-        ("\"vector_less__ad_scope_rss_scope_world_scope_LaneSegment__greater_\"", "\"RoadSegment\"")
+        ("\"vector_less__ad_scope_rss_scope_world_scope_LaneSegment__greater_\"", "\"RoadSegment\""),
+        ("\"vector_less_ad_scope_rss_scope_world_scope_LaneSegment_greater_\"", "\"RoadSegment\"")
     }
 
     for component in ["core", "situation", "state", "unstructured", "world"]:

--- a/ad_rss_map_integration/tests/RssSceneCreationTest.hpp
+++ b/ad_rss_map_integration/tests/RssSceneCreationTest.hpp
@@ -19,6 +19,7 @@
 #include <ad/rss/world/WorldModelValidInputRange.hpp>
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <fstream>
 #include <streambuf>
 

--- a/colcon.meta
+++ b/colcon.meta
@@ -4,7 +4,7 @@
             "cmake-args": ["-DCMAKE_POSITION_INDEPENDENT_CODE=ON", "-DSPDLOG_BUILD_TESTS=OFF", "-DSPDLOG_BUILD_EXAMPLE=Off"]
         },
         "ad_map_opendrive_reader": {
-            "dependencies": ["odrSpiral"]
+            "dependencies": ["odrSpiral", "PROJ4"]
         }
     }
 }

--- a/colcon_python.meta
+++ b/colcon_python.meta
@@ -7,7 +7,7 @@
             "cmake-args": ["-DBUILD_PYTHON_BINDING=ON"]
         },
         "ad_map_opendrive_reader": {
-            "dependencies": ["odrSpiral"]
+            "dependencies": ["odrSpiral", "PROJ4"]
         },
         "ad_map_access": {
             "cmake-args": ["-DBUILD_PYTHON_BINDING=ON"]


### PR DESCRIPTION
* Updated github workflow to still build on 18.04
* Added support for clang-10 on 20.04
* Added support for gcc-11 and clang-14 on 22.04

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel/ad-rss-lib/137)
<!-- Reviewable:end -->
